### PR TITLE
fixes #2852 - Failing tests Unrecognised option '--name'

### DIFF
--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -23,7 +23,7 @@ EOF
   s.require_paths = ["lib"]
 
   s.add_dependency 'hammer_cli'
-  s.add_dependency 'foreman_api'
+  s.add_dependency 'foreman_api', '>= 0.1.5'
   s.add_dependency 'awesome_print'
   s.add_dependency 'terminal-table'
 


### PR DESCRIPTION
The issue was originating in apipie gem. New version of foreman_api regenerated with fixed apipie solves the problem.
