### PR TITLE
fixes #2961 - Refactoring of output and formatters

### DIFF
--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -1,12 +1,15 @@
 require 'hammer_cli'
 require 'hammer_cli/exit_codes'
 
+require 'hammer_cli_foreman/output/fields'
+
 module HammerCLIForeman
 
   def self.exception_handler_class
     HammerCLIForeman::ExceptionHandler
   end
-
+  
+  require 'hammer_cli_foreman/output'
   require 'hammer_cli_foreman/exception_handler'
   require 'hammer_cli_foreman/architecture'
   require 'hammer_cli_foreman/common_parameter'

--- a/lib/hammer_cli_foreman/architecture.rb
+++ b/lib/hammer_cli_foreman/architecture.rb
@@ -26,9 +26,9 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "architecture" do
-          field :operatingsystem_ids, "OS ids", HammerCLI::Output::Fields::List
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :operatingsystem_ids, "OS ids", Fields::List
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -11,9 +11,12 @@ module HammerCLIForeman
     end
 
     def output
+ 
       @output ||= HammerCLI::Output::Output.new(
+            :context => context,
             :definition => output_definition,
-            :adapter => HammerCLI::Output::Adapter::Table.new)
+            :adapter => HammerCLI::Output::Adapter::Table.new(
+              context, HammerCLIForeman::Output::Formatters::DEFAULT_FORMATTERS))
 
     end
 
@@ -37,6 +40,15 @@ module HammerCLIForeman
     def self.apipie_options(options={})
       super(options.merge(:without => declared_identifiers.keys))
     end
+
+    def output
+      @output ||= HammerCLI::Output::Output.new(
+            :context => context,
+            :definition => output_definition,
+            :adapter => HammerCLI::Output::Adapter::Base.new(
+              context, HammerCLIForeman::Output::Formatters::DEFAULT_FORMATTERS))
+    end
+
   end
 
 

--- a/lib/hammer_cli_foreman/compute_resource.rb
+++ b/lib/hammer_cli_foreman/compute_resource.rb
@@ -25,20 +25,20 @@ module HammerCLIForeman
 
       PROVIDER_SPECIFIC_FIELDS = {
         'ovirt' => [
-          HammerCLI::Output::DataField.new(:label => 'UUID', :path => ["compute_resource", "uuid"])
+          Fields::DataField.new(:label => 'UUID', :path => ["compute_resource", "uuid"])
         ],
         'ec2' => [
-          HammerCLI::Output::DataField.new(:label => 'Region', :path => ["compute_resource", "region"])
+          Fields::DataField.new(:label => 'Region', :path => ["compute_resource", "region"])
         ],
         'vmware' => [
-          HammerCLI::Output::DataField.new(:label => 'UUID', :path => ["compute_resource", "uuid"]),
-          HammerCLI::Output::DataField.new(:label => 'Server', :path => ["compute_resource", "server"])
+          Fields::DataField.new(:label => 'UUID', :path => ["compute_resource", "uuid"]),
+          Fields::DataField.new(:label => 'Server', :path => ["compute_resource", "server"])
         ],
         'openstack' => [
-          HammerCLI::Output::DataField.new(:label => 'Tenant', :path => ["compute_resource", "tenant"])
+          Fields::DataField.new(:label => 'Tenant', :path => ["compute_resource", "tenant"])
         ],
         'rackspace' => [
-          HammerCLI::Output::DataField.new(:label => 'Region', :path => ["compute_resource", "region"])
+          Fields::DataField.new(:label => 'Region', :path => ["compute_resource", "region"])
         ],
         'libvirt' => [
         ]
@@ -51,8 +51,8 @@ module HammerCLIForeman
           field :url, "Url"
           field :description, "Description"
           field :user, "User"
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/domain.rb
+++ b/lib/hammer_cli_foreman/domain.rb
@@ -34,11 +34,11 @@ module HammerCLIForeman
         from "domain" do
           field :fullname, "Full Name"
           field :dns_id, "DNS Id"
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
         collection :parameters, "Parameters" do
-          field :parameter, nil, HammerCLI::Output::Fields::KeyValue
+          field :parameter, nil, Fields::KeyValue
         end
       end
 

--- a/lib/hammer_cli_foreman/environment.rb
+++ b/lib/hammer_cli_foreman/environment.rb
@@ -24,8 +24,8 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "environment" do
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -59,10 +59,10 @@ module HammerCLIForeman
           field :sp_subnet, "SP Subnet"
           field :sp_subnet_id, "SP Subnet Id"
 
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
-          field :installed_at, "Installed at", HammerCLI::Output::Fields::Date
-          field :last_report, "Last report", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
+          field :installed_at, "Installed at", Fields::Date
+          field :last_report, "Last report", Fields::Date
 
           field :puppet_ca_proxy_id, "Puppet CA Proxy Id"
           field :medium_id, "Medium Id"
@@ -80,7 +80,7 @@ module HammerCLIForeman
           field :comment, "Comment"
         end
         collection :parameters, "Parameters" do
-          field :parameter, nil, HammerCLI::Output::Fields::KeyValue
+          field :parameter, nil, Fields::KeyValue
         end
       end
     end

--- a/lib/hammer_cli_foreman/hostgroup.rb
+++ b/lib/hammer_cli_foreman/hostgroup.rb
@@ -18,7 +18,7 @@ module HammerCLIForeman
           field :subnet_id, "Subnet Id"
           field :domain_id, "Domain Id"
           field :environment_id, "Environment Id"
-          field :puppetclass_ids, "Puppetclass Ids", HammerCLI::Output::Fields::List
+          field :puppetclass_ids, "Puppetclass Ids", Fields::List
           field :ancestry, "Ancestry"
         end
       end
@@ -34,7 +34,7 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         collection :parameters, "Parameters" do
-          field :parameter, nil, HammerCLI::Output::Fields::KeyValue
+          field :parameter, nil, Fields::KeyValue
         end
       end
 

--- a/lib/hammer_cli_foreman/location.rb
+++ b/lib/hammer_cli_foreman/location.rb
@@ -29,8 +29,8 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "location" do
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/media.rb
+++ b/lib/hammer_cli_foreman/media.rb
@@ -26,9 +26,9 @@ module HammerCLIForeman
       output ListCommand.output_definition do
         from "medium" do
           field :os_family, "OS Family"
-          field :operatingsystem_ids, "OS IDs", HammerCLI::Output::Fields::List
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :operatingsystem_ids, "OS IDs", Fields::List
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/model.rb
+++ b/lib/hammer_cli_foreman/model.rb
@@ -28,8 +28,8 @@ module HammerCLIForeman
       output ListCommand.output_definition do
         from "model" do
           field :info, "Info"
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/operating_system.rb
+++ b/lib/hammer_cli_foreman/operating_system.rb
@@ -15,7 +15,7 @@ module HammerCLIForeman
         from "operatingsystem" do
           field :id, "Id"
         end
-        field :operatingsystem, "Name", HammerCLI::Output::Fields::OSName
+        field :operatingsystem, "Name", Fields::OSName
         from "operatingsystem" do
           field :release_name, "Release name"
           field :family, "Family"
@@ -32,13 +32,13 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "operatingsystem" do
-          field :media_names, "Installation media", HammerCLI::Output::Fields::List
-          field :architecture_names, "Architectures", HammerCLI::Output::Fields::List
-          field :ptable_names, "Partition tables", HammerCLI::Output::Fields::List
-          field :config_template_names, "Config templates", HammerCLI::Output::Fields::List
+          field :media_names, "Installation media", Fields::List
+          field :architecture_names, "Architectures", Fields::List
+          field :ptable_names, "Partition tables", Fields::List
+          field :config_template_names, "Config templates", Fields::List
         end
         collection :parameters, "Parameters" do
-          field :parameter, nil, HammerCLI::Output::Fields::KeyValue
+          field :parameter, nil, Fields::KeyValue
         end
       end
 

--- a/lib/hammer_cli_foreman/organization.rb
+++ b/lib/hammer_cli_foreman/organization.rb
@@ -29,8 +29,8 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "organization" do
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/output.rb
+++ b/lib/hammer_cli_foreman/output.rb
@@ -1,0 +1,2 @@
+require File.join(File.dirname(__FILE__), 'output/fields')
+require File.join(File.dirname(__FILE__), 'output/formatters')

--- a/lib/hammer_cli_foreman/output/fields.rb
+++ b/lib/hammer_cli_foreman/output/fields.rb
@@ -1,0 +1,11 @@
+require 'hammer_cli'
+
+module Fields
+
+  class OSName < DataField
+  end
+
+  class Server < DataField
+  end
+
+end

--- a/lib/hammer_cli_foreman/output/formatters.rb
+++ b/lib/hammer_cli_foreman/output/formatters.rb
@@ -1,0 +1,23 @@
+module HammerCLIForeman::Output
+  module Formatters
+
+    class OSNameFormatter < HammerCLI::Output::Formatters::FieldFormatter
+      def format(os)
+        name = "%s %s" % [os[:name], os[:major]]
+        name += ".%s" % os[:minor] unless os[:minor].nil?
+        name
+      end
+    end
+
+    class ServerFormatter < HammerCLI::Output::Formatters::FieldFormatter
+      def format(server)
+        "%s (%s)" % [server[:name], server[:url]]
+      end
+    end
+
+    DEFAULT_FORMATTERS = HammerCLI::Output::Formatters::DEFAULT_FORMATTERS
+    DEFAULT_FORMATTERS.register_formatter(:OSName, OSNameFormatter.new)
+    DEFAULT_FORMATTERS.register_formatter(:Server, ServerFormatter.new)
+
+  end
+end

--- a/lib/hammer_cli_foreman/partition_table.rb
+++ b/lib/hammer_cli_foreman/partition_table.rb
@@ -27,8 +27,8 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "ptable" do
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/report.rb
+++ b/lib/hammer_cli_foreman/report.rb
@@ -14,7 +14,7 @@ module HammerCLIForeman
         from "report" do
           field :id, "Id"
           field :host_name, "Host"
-          field :reported_at, "Last report", HammerCLI::Output::Fields::Date
+          field :reported_at, "Last report", Fields::Date
           from "status" do
             field :applied, "Applied"
             field :restarted, "Restarted"
@@ -38,7 +38,7 @@ module HammerCLIForeman
         from "report" do
           field :id, "Id"
           field :host_name, "Host"
-          field :reported_at, "Reported at", HammerCLI::Output::Fields::Date
+          field :reported_at, "Reported at", Fields::Date
           label "Report status" do
             from "status" do
               field :applied, "Applied"
@@ -65,7 +65,7 @@ module HammerCLIForeman
               end
             end
           end
-          field :logs, "Logs", HammerCLI::Output::Fields::Collection do
+          field :logs, "Logs", Fields::Collection do
             from :log do
               from :source do
                 field :source, "Resource"

--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -33,9 +33,9 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "smart_proxy" do
-          field :_features,  "Features",   HammerCLI::Output::Fields::List
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :_features,  "Features",   Fields::List
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/lib/hammer_cli_foreman/subnet.rb
+++ b/lib/hammer_cli_foreman/subnet.rb
@@ -28,13 +28,13 @@ module HammerCLIForeman
       output ListCommand.output_definition do
         from "subnet" do
           field :priority, "Priority"
-          field :dns, "DNS", HammerCLI::Output::Fields::Server
+          field :dns, "DNS", Fields::Server
           field :dns_primary, "Primary DNS"
           field :dns_secondary, "Secondary DNS"
-          field :domain_ids, "Domain ids", HammerCLI::Output::Fields::List
-          field :tftp, "TFTP", HammerCLI::Output::Fields::Server
+          field :domain_ids, "Domain ids", Fields::List
+          field :tftp, "TFTP", Fields::Server
           field :tftp_id, "TFTP id"
-          field :dhcp, "DHCP", HammerCLI::Output::Fields::Server
+          field :dhcp, "DHCP", Fields::Server
           field :dhcp_id, "DHCP id"
           field :vlanid, "vlan id"
           field :gateway, "Gateway"

--- a/lib/hammer_cli_foreman/template.rb
+++ b/lib/hammer_cli_foreman/template.rb
@@ -42,7 +42,7 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "config_template" do
-          field :operatingsystem_ids, "OS ids", HammerCLI::Output::Fields::List
+          field :operatingsystem_ids, "OS ids", Fields::List
         end
       end
 

--- a/lib/hammer_cli_foreman/user.rb
+++ b/lib/hammer_cli_foreman/user.rb
@@ -42,9 +42,9 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         from "user" do
-          field :last_login_on, "Last login", HammerCLI::Output::Fields::Date
-          field :created_at, "Created at", HammerCLI::Output::Fields::Date
-          field :updated_at, "Updated at", HammerCLI::Output::Fields::Date
+          field :last_login_on, "Last login", Fields::Date
+          field :created_at, "Created at", Fields::Date
+          field :updated_at, "Updated at", Fields::Date
         end
       end
 

--- a/test/unit/output/formatters_test.rb
+++ b/test/unit/output/formatters_test.rb
@@ -1,0 +1,19 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+
+describe HammerCLIForeman::Output::Formatters::OSNameFormatter do
+  it "formats the os name" do
+    formatter = HammerCLIForeman::Output::Formatters::OSNameFormatter.new
+    formatter.format({ :name => 'OS', :major => '1', :minor => '2' }).must_equal 'OS 1.2'
+  end
+  it "formats the os name with only major version" do
+    formatter = HammerCLIForeman::Output::Formatters::OSNameFormatter.new
+    formatter.format({ :name => 'Fedora', :major => '19'}).must_equal 'Fedora 19'
+  end
+end
+
+describe HammerCLIForeman::Output::Formatters::ServerFormatter do
+  it "formats the server" do
+    formatter = HammerCLIForeman::Output::Formatters::ServerFormatter.new
+    formatter.format({ :name => 'Server', :url => "URL"}).must_equal 'Server (URL)'
+  end
+end


### PR DESCRIPTION
Foreman side of output refactoring
- shortened field types names
- foreman specific fields and formatters moved
