### PR TITLE
fixes #3534 - mime-types require ruby >= 1.9.2 since 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'hammer_cli', :github => "theforeman/hammer-cli"
+gem 'mime-types', '< 2.0.0', :platforms => [:ruby_18]
 
 gem 'pry'
 gem 'pry-debugger', :platforms => [:ruby_19]

--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -24,5 +24,6 @@ EOF
 
   s.add_dependency 'hammer_cli', '>= 0.0.6'
   s.add_dependency 'foreman_api', '>= 0.1.7'
+  s.add_dependency 'mime-types', '< 2.0.0' if RUBY_VERSION < "1.9.0"
 
 end


### PR DESCRIPTION
mime-types version pinned < 2.0 for ruby 1.8.7
