### PR TITLE
Fixed #3766 - API v2 response format changed

### DIFF
--- a/lib/hammer_cli_foreman/architecture.rb
+++ b/lib/hammer_cli_foreman/architecture.rb
@@ -12,10 +12,8 @@ module HammerCLIForeman
     class ListCommand < HammerCLIForeman::ListCommand
 
       output do
-        from "architecture" do
-          field :id, "Id"
-          field :name, "Name"
-        end
+        field :id, "Id"
+        field :name, "Name"
       end
 
       apipie_options
@@ -25,11 +23,9 @@ module HammerCLIForeman
     class InfoCommand < HammerCLIForeman::InfoCommand
 
       output ListCommand.output_definition do
-        from "architecture" do
-          field :operatingsystem_ids, "OS ids", Fields::List
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :operatingsystem_ids, "OS ids", Fields::List
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
     end

--- a/lib/hammer_cli_foreman/common_parameter.rb
+++ b/lib/hammer_cli_foreman/common_parameter.rb
@@ -10,10 +10,8 @@ module HammerCLIForeman
       resource ForemanApi::Resources::CommonParameter, "index"
 
       output do
-        from "common_parameter" do
-          field :name, "Name"
-          field :value, "Value"
-        end
+        field :name, "Name"
+        field :value, "Value"
       end
 
       apipie_options

--- a/lib/hammer_cli_foreman/compute_resource.rb
+++ b/lib/hammer_cli_foreman/compute_resource.rb
@@ -11,11 +11,9 @@ module HammerCLIForeman
     class ListCommand < HammerCLIForeman::ListCommand
 
       output do
-        from "compute_resource" do
-          field :id, "Id"
-          field :name, "Name"
-          field :provider, "Provider"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :provider, "Provider"
       end
 
       apipie_options
@@ -46,19 +44,17 @@ module HammerCLIForeman
       }
 
       output ListCommand.output_definition do
-        from "compute_resource" do
-          field :url, "Url"
-          field :description, "Description"
-          field :user, "User"
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :url, "Url"
+        field :description, "Description"
+        field :user, "User"
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
       def print_data(data)
-        provider = data["compute_resource"]["provider"].downcase
+        provider = data["provider"].downcase
         output_definition.fields.concat PROVIDER_SPECIFIC_FIELDS[provider]
-        print_records(output_definition, data)
+        print_collection(output_definition, data)
       end
 
     end

--- a/lib/hammer_cli_foreman/domain.rb
+++ b/lib/hammer_cli_foreman/domain.rb
@@ -10,10 +10,8 @@ module HammerCLIForeman
       resource ForemanApi::Resources::Domain, "index"
 
       output do
-        from "domain" do
-          field :id, "Id"
-          field :name, "Name"
-        end
+        field :id, "Id"
+        field :name, "Name"
       end
 
       apipie_options
@@ -24,22 +22,19 @@ module HammerCLIForeman
 
       resource ForemanApi::Resources::Domain, "show"
 
-      def retrieve_data
-        domain = super
-        domain["parameters"] = HammerCLIForeman::Parameter.get_parameters resource_config, domain
-        domain
+      output ListCommand.output_definition do
+        field :fullname, "Description"
+        field :dns_id, "DNS Id"
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
+        collection :parameters, "Parameters" do
+          field nil, nil, Fields::KeyValue
+        end
       end
 
-      output ListCommand.output_definition do
-        from "domain" do
-          field :fullname, "Description"
-          field :dns_id, "DNS Id"
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
-        collection :parameters, "Parameters" do
-          field :parameter, nil, Fields::KeyValue
-        end
+      def extend_data(record)
+        record["parameters"] = HammerCLIForeman::Parameter.get_parameters(resource_config, :domain, record)
+        record
       end
 
     end

--- a/lib/hammer_cli_foreman/environment.rb
+++ b/lib/hammer_cli_foreman/environment.rb
@@ -11,10 +11,8 @@ module HammerCLIForeman
       resource ForemanApi::Resources::Environment, "index"
 
       output do
-        from "environment" do
-          field :id, "Id"
-          field :name, "Name"
-        end
+        field :id, "Id"
+        field :name, "Name"
       end
 
       apipie_options
@@ -25,10 +23,8 @@ module HammerCLIForeman
       resource ForemanApi::Resources::Environment, "show"
 
       output ListCommand.output_definition do
-        from "environment" do
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
     end
@@ -66,8 +62,8 @@ module HammerCLIForeman
     class SCParamsCommand < HammerCLIForeman::SmartClassParametersList
 
       apipie_options :without => [:host_id, :hostgroup_id, :puppetclass_id, :environment_id]
-      option ['--id', '--name'], 'ENVIRONMENT_ID', 'environment id/name', 
-            :required => true, :attribute_name => :environment_id 
+      option ['--id', '--name'], 'ENVIRONMENT_ID', 'environment id/name',
+            :required => true, :attribute_name => :environment_id
     end
 
 

--- a/lib/hammer_cli_foreman/fact.rb
+++ b/lib/hammer_cli_foreman/fact.rb
@@ -13,11 +13,9 @@ module HammerCLIForeman
       apipie_options
 
       output do
-        from "fact" do
-          field :host, "Host"
-          field :fact, "Fact"
-          field :value, "Value"
-        end
+        field :host, "Host"
+        field :fact, "Fact"
+        field :value, "Value"
       end
 
       def retrieve_data
@@ -25,13 +23,13 @@ module HammerCLIForeman
       end
 
       def self.unhash_facts(facts_hash)
-        facts_hash.inject([]) do |list, (host, facts)|
+        facts = facts_hash.first.inject([]) do |list, (host, facts)|
           list + facts.collect do |(fact, value)|
-            { :fact => { :host => host, :fact => fact, :value => value } }
+            { :host => host, :fact => fact, :value => value }
           end
         end
+        HammerCLI::Output::RecordCollection.new(facts, :meta => facts_hash.meta)
       end
-
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -99,14 +99,12 @@ module HammerCLIForeman
     class ListCommand < HammerCLIForeman::ListCommand
       # FIXME: list compute resource (model)
       output do
-        from "host" do
-          field :id, "Id"
-          field :name, "Name"
-          field :operatingsystem_id, "Operating System Id"
-          field :hostgroup_id, "Host Group Id"
-          field :ip, "IP"
-          field :mac, "MAC"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :operatingsystem_id, "Operating System Id"
+        field :hostgroup_id, "Host Group Id"
+        field :ip, "IP"
+        field :mac, "MAC"
       end
 
       apipie_options
@@ -115,57 +113,55 @@ module HammerCLIForeman
 
     class InfoCommand < HammerCLIForeman::InfoCommand
 
-      def retrieve_data
-        host = super
-        host["host"]["environment_name"] = host["host"]["environment"]["environment"]["name"] rescue nil
-        host["parameters"] = HammerCLIForeman::Parameter.get_parameters(resource_config, host)
+      def extend_data(host)
+        host["environment_name"] = host["environment"]["environment"]["name"] rescue nil
+        host["parameters"] = HammerCLIForeman::Parameter.get_parameters(resource_config, :host, host)
         host
       end
 
       output ListCommand.output_definition do
-        from "host" do
-          field :uuid, "UUID"
-          field :certname, "Cert name"
+        field :uuid, "UUID"
+        field :certname, "Cert name"
 
-          field :environment_name, "Environment"
-          field :environment_id, "Environment Id"
+        field :environment_name, "Environment"
+        field :environment_id, "Environment Id"
 
-          field :managed, "Managed"
-          field :enabled, "Enabled"
-          field :build, "Build"
+        field :managed, "Managed"
+        field :enabled, "Enabled"
+        field :build, "Build"
 
-          field :use_image, "Use image"
-          field :disk, "Disk"
-          field :image_file, "Image file"
+        field :use_image, "Use image"
+        field :disk, "Disk"
+        field :image_file, "Image file"
 
-          field :sp_name, "SP Name"
-          field :sp_ip, "SP IP"
-          field :sp_mac, "SP MAC"
-          field :sp_subnet, "SP Subnet"
-          field :sp_subnet_id, "SP Subnet Id"
+        field :sp_name, "SP Name"
+        field :sp_ip, "SP IP"
+        field :sp_mac, "SP MAC"
+        field :sp_subnet, "SP Subnet"
+        field :sp_subnet_id, "SP Subnet Id"
 
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-          field :installed_at, "Installed at", Fields::Date
-          field :last_report, "Last report", Fields::Date
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
+        field :installed_at, "Installed at", Fields::Date
+        field :last_report, "Last report", Fields::Date
 
-          field :puppet_ca_proxy_id, "Puppet CA Proxy Id"
-          field :medium_id, "Medium Id"
-          field :model_id, "Model Id"
-          field :owner_id, "Owner Id"
-          field :subnet_id, "Subnet Id"
-          field :domain_id, "Domain Id"
-          field :puppet_proxy_id, "Puppet Proxy Id"
-          field :owner_type, "Owner Type"
-          field :ptable_id, "Partition Table Id"
-          field :architecture_id, "Architecture Id"
-          field :image_id, "Image Id"
-          field :compute_resource_id, "Compute Resource Id"
+        field :puppet_ca_proxy_id, "Puppet CA Proxy Id"
+        field :medium_id, "Medium Id"
+        field :model_id, "Model Id"
+        field :owner_id, "Owner Id"
+        field :subnet_id, "Subnet Id"
+        field :domain_id, "Domain Id"
+        field :puppet_proxy_id, "Puppet Proxy Id"
+        field :owner_type, "Owner Type"
+        field :ptable_id, "Partition Table Id"
+        field :architecture_id, "Architecture Id"
+        field :image_id, "Image Id"
+        field :compute_resource_id, "Compute Resource Id"
 
-          field :comment, "Comment"
-        end
+        field :comment, "Comment"
+
         collection :parameters, "Parameters" do
-          field :parameter, nil, Fields::KeyValue
+          field nil, nil, Fields::KeyValue
         end
       end
     end
@@ -228,10 +224,8 @@ module HammerCLIForeman
       apipie_options :without => declared_identifiers.keys
 
       output do
-        from "fact" do
-          field :fact, "Fact"
-          field :value, "Value"
-        end
+        field :fact, "Fact"
+        field :value, "Value"
       end
 
       def request_params
@@ -241,7 +235,8 @@ module HammerCLIForeman
       end
 
       def retrieve_data
-        HammerCLIForeman::Fact::ListCommand.unhash_facts(super)
+        data = super
+        HammerCLIForeman::Fact::ListCommand.unhash_facts(data)
       end
 
     end
@@ -427,7 +422,7 @@ module HammerCLIForeman
     class SCParamsCommand < HammerCLIForeman::SmartClassParametersList
 
       apipie_options :without => [:host_id, :hostgroup_id, :puppetclass_id, :environment_id]
-      option ['--id', '--name'], 'HOST_ID', 'host id/name', 
+      option ['--id', '--name'], 'HOST_ID', 'host id/name',
               :attribute_name => :host_id, :required => true
     end
 

--- a/lib/hammer_cli_foreman/hostgroup.rb
+++ b/lib/hammer_cli_foreman/hostgroup.rb
@@ -11,17 +11,15 @@ module HammerCLIForeman
       resource ForemanApi::Resources::Hostgroup, "index"
 
       output do
-        from "hostgroup" do
-          field :id, "Id"
-          field :name, "Name"
-          field :label, "Label"
-          field :operatingsystem_id, "Operating System Id"
-          field :subnet_id, "Subnet Id"
-          field :domain_id, "Domain Id"
-          field :environment_id, "Environment Id"
-          field :puppetclass_ids, "Puppetclass Ids", Fields::List
-          field :ancestry, "Ancestry"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :label, "Label"
+        field :operatingsystem_id, "Operating System Id"
+        field :subnet_id, "Subnet Id"
+        field :domain_id, "Domain Id"
+        field :environment_id, "Environment Id"
+        field :puppetclass_ids, "Puppetclass Ids", Fields::List
+        field :ancestry, "Ancestry"
       end
 
       apipie_options
@@ -35,13 +33,12 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         collection :parameters, "Parameters" do
-          field :parameter, nil, Fields::KeyValue
+          field nil, nil, Fields::KeyValue
         end
       end
 
-      def retrieve_data
-        hostgroup = super
-        hostgroup["parameters"] = HammerCLIForeman::Parameter.get_parameters resource_config, hostgroup
+      def extend_data(hostgroup)
+        hostgroup["parameters"] = HammerCLIForeman::Parameter.get_parameters(resource_config, :hostgroup, hostgroup)
         hostgroup
       end
 
@@ -142,7 +139,7 @@ module HammerCLIForeman
     class SCParamsCommand < HammerCLIForeman::SmartClassParametersList
 
       apipie_options :without => [:host_id, :hostgroup_id, :puppetclass_id, :environment_id]
-      option ['--id', '--name'], 'HOSTGROUP_ID', 'hostgroup id/name', 
+      option ['--id', '--name'], 'HOSTGROUP_ID', 'hostgroup id/name',
             :attribute_name => :hostgroup_id, :required => true
     end
 

--- a/lib/hammer_cli_foreman/image.rb
+++ b/lib/hammer_cli_foreman/image.rb
@@ -32,13 +32,11 @@ module HammerCLIForeman
       include HammerCLIForeman::Image::ComputeResourceOptions
 
       output do
-        from "image" do
-          field :id, "Id"
-          field :name, "Name"
-          field :operatingsystem_id, "Operating System Id", Fields::Id
-          field :username, "Username"
-          field :uuid, "UUID"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :operatingsystem_id, "Operating System Id", Fields::Id
+        field :username, "Username"
+        field :uuid, "UUID"
       end
 
       def request_params
@@ -57,12 +55,10 @@ module HammerCLIForeman
       identifiers :id
 
       output ListCommand.output_definition do
-        from "image" do
-          field :architecture_id, "Architecture Id", Fields::Id
-          field :iam_role, "IAM role"
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :architecture_id, "Architecture Id", Fields::Id
+        field :iam_role, "IAM role"
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
       def request_params
@@ -83,10 +79,8 @@ module HammerCLIForeman
       include HammerCLIForeman::Image::ComputeResourceOptions
 
       output do
-        from "image" do
-          field :name, "Name"
-          field :uuid, "UUID"
-        end
+        field :name, "Name"
+        field :uuid, "UUID"
       end
 
       def request_params

--- a/lib/hammer_cli_foreman/location.rb
+++ b/lib/hammer_cli_foreman/location.rb
@@ -14,10 +14,8 @@ module HammerCLIForeman
       include HammerCLIForeman::ResourceSupportedTest
 
       output do
-        from "location" do
-          field :id, "Id"
-          field :name, "Name"
-        end
+        field :id, "Id"
+        field :name, "Name"
       end
 
       apipie_options
@@ -28,10 +26,8 @@ module HammerCLIForeman
       include HammerCLIForeman::ResourceSupportedTest
 
       output ListCommand.output_definition do
-        from "location" do
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
     end

--- a/lib/hammer_cli_foreman/media.rb
+++ b/lib/hammer_cli_foreman/media.rb
@@ -11,11 +11,9 @@ module HammerCLIForeman
 
     class ListCommand < HammerCLIForeman::ListCommand
       output do
-        from "medium" do
-          field :id, "Id"
-          field :name, "Name"
-          field :path, "Path"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :path, "Path"
       end
 
       apipie_options
@@ -24,12 +22,10 @@ module HammerCLIForeman
 
     class InfoCommand < HammerCLIForeman::InfoCommand
       output ListCommand.output_definition do
-        from "medium" do
-          field :os_family, "OS Family"
-          field :operatingsystem_ids, "OS IDs", Fields::List
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :os_family, "OS Family"
+        field :operatingsystem_ids, "OS IDs", Fields::List
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
     end

--- a/lib/hammer_cli_foreman/model.rb
+++ b/lib/hammer_cli_foreman/model.rb
@@ -11,12 +11,10 @@ module HammerCLIForeman
     class ListCommand < HammerCLIForeman::ListCommand
 
       output do
-        from "model" do
-          field :id, "Id"
-          field :name, "Name"
-          field :vendor_class, "Vendor class"
-          field :hardware_model, "HW model"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :vendor_class, "Vendor class"
+        field :hardware_model, "HW model"
       end
 
       apipie_options
@@ -26,11 +24,9 @@ module HammerCLIForeman
     class InfoCommand < HammerCLIForeman::InfoCommand
 
       output ListCommand.output_definition do
-        from "model" do
-          field :info, "Info"
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :info, "Info"
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
     end

--- a/lib/hammer_cli_foreman/organization.rb
+++ b/lib/hammer_cli_foreman/organization.rb
@@ -14,10 +14,8 @@ module HammerCLIForeman
       include HammerCLIForeman::ResourceSupportedTest
 
       output do
-        from "organization" do
-          field :id, "Id"
-          field :name, "Name"
-        end
+        field :id, "Id"
+        field :name, "Name"
       end
 
       apipie_options
@@ -28,10 +26,8 @@ module HammerCLIForeman
       include HammerCLIForeman::ResourceSupportedTest
 
       output ListCommand.output_definition do
-        from "organization" do
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
     end

--- a/lib/hammer_cli_foreman/output/formatters.rb
+++ b/lib/hammer_cli_foreman/output/formatters.rb
@@ -8,6 +8,7 @@ module HammerCLIForeman::Output
       end
 
       def format(os)
+        return nil if os.nil?
         name = "%s %s" % [os[:name], os[:major]]
         name += ".%s" % os[:minor] unless (!os.has_key?(:minor) || os[:minor].empty?)
         name
@@ -15,13 +16,13 @@ module HammerCLIForeman::Output
     end
 
     class ServerFormatter < HammerCLI::Output::Formatters::FieldFormatter
-      
+
       def tags
         [:flat]
       end
 
       def format(server)
-        "%s (%s)" % [server[:name], server[:url]]
+        "%s (%s)" % [server[:name], server[:url]] unless server.nil?
       end
     end
 

--- a/lib/hammer_cli_foreman/parameter.rb
+++ b/lib/hammer_cli_foreman/parameter.rb
@@ -6,14 +6,13 @@ module HammerCLIForeman
 
   module Parameter
 
-    def self.get_parameters(resource_config, resource)
-      resource_type = resource.keys.first
-      resource = resource[resource_type]
+    def self.get_parameters(resource_config, resource_type, resource)
       params = {
         resource_type.to_s+"_id" => resource["id"] || resource["name"]
       }
 
-      ForemanApi::Resources::Parameter.new(resource_config).index(params)[0]
+      params = ForemanApi::Resources::Parameter.new(resource_config).index(params)[0]
+      HammerCLIForeman.collection_to_common_format(params)
     end
 
     class SetCommand < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/partition_table.rb
+++ b/lib/hammer_cli_foreman/partition_table.rb
@@ -12,11 +12,9 @@ module HammerCLIForeman
     class ListCommand < HammerCLIForeman::ListCommand
 
       output do
-        from "ptable" do
-          field :id, "Id"
-          field :name, "Name"
-          field :os_family, "OS Family"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :os_family, "OS Family"
       end
 
       apipie_options
@@ -26,10 +24,8 @@ module HammerCLIForeman
     class InfoCommand < HammerCLIForeman::InfoCommand
 
       output ListCommand.output_definition do
-        from "ptable" do
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
     end
@@ -42,7 +38,7 @@ module HammerCLIForeman
 
 
       def print_data(partition_table)
-        puts partition_table["ptable"]["layout"]
+        puts partition_table["layout"]
       end
 
     end

--- a/lib/hammer_cli_foreman/puppet_class.rb
+++ b/lib/hammer_cli_foreman/puppet_class.rb
@@ -12,10 +12,8 @@ module HammerCLIForeman
     class ListCommand < HammerCLIForeman::ListCommand
 
       output do
-        from "puppetclass" do
-          field :id, "Id"
-          field :name, "Name"
-        end
+        field :id, "Id"
+        field :name, "Name"
       end
 
       def retrieve_data
@@ -23,7 +21,10 @@ module HammerCLIForeman
       end
 
       def self.unhash_classes(classes)
-        classes.inject([]) { |list, (pp_module, pp_module_classes)| list + pp_module_classes }
+        clss = classes.first.inject([]) { |list, (pp_module, pp_module_classes)| list + pp_module_classes }
+
+        HammerCLI::Output::RecordCollection.new(clss, :meta => classes.meta)
+
       end
 
       apipie_options
@@ -32,14 +33,12 @@ module HammerCLIForeman
 
     class InfoCommand < HammerCLIForeman::InfoCommand
 
-      #FIXME: show environments and hostgroups
+      #FIXME: show environments, hostgroups, variables and parameters
       output ListCommand.output_definition do
-        from "puppetclass" do
-          collection :lookup_keys, "Smart variables" do
-            from :lookup_key do
-              field :key, "Parameter"
-              field :default_value, "Default value"
-            end
+        collection :lookup_keys, "Smart variables" do
+          from :lookup_key do
+            field :key, "Parameter"
+            field :default_value, "Default value"
           end
         end
       end
@@ -50,7 +49,7 @@ module HammerCLIForeman
     class SCParamsCommand < HammerCLIForeman::SmartClassParametersBriefList
 
       apipie_options :without => [:host_id, :hostgroup_id, :puppetclass_id, :environment_id]
-      option ['--id', '--name'], 'PUPPET_CLASS_ID', 'puppet class id/name', 
+      option ['--id', '--name'], 'PUPPET_CLASS_ID', 'puppet class id/name',
               :attribute_name => :puppetclass_id, :required => true
     end
 

--- a/lib/hammer_cli_foreman/report.rb
+++ b/lib/hammer_cli_foreman/report.rb
@@ -11,18 +11,16 @@ module HammerCLIForeman
     class ListCommand < HammerCLIForeman::ListCommand
 
       output do
-        from "report" do
-          field :id, "Id"
-          field :host_name, "Host"
-          field :reported_at, "Last report", Fields::Date
-          from "status" do
-            field :applied, "Applied"
-            field :restarted, "Restarted"
-            field :failed, "Failed"
-            field :failed_restarts, "Restart Failures"
-            field :skipped, "Skipped"
-            field :pending, "Pending"
-          end
+        field :id, "Id"
+        field :host_name, "Host"
+        field :reported_at, "Last report", Fields::Date
+        from "status" do
+          field :applied, "Applied"
+          field :restarted, "Restarted"
+          field :failed, "Failed"
+          field :failed_restarts, "Restart Failures"
+          field :skipped, "Skipped"
+          field :pending, "Pending"
         end
       end
 
@@ -35,44 +33,42 @@ module HammerCLIForeman
       identifiers :id
 
       output do
-        from "report" do
-          field :id, "Id"
-          field :host_name, "Host"
-          field :reported_at, "Reported at", Fields::Date
-          label "Report status" do
-            from "status" do
-              field :applied, "Applied"
-              field :restarted, "Restarted"
-              field :failed, "Failed"
-              field :failed_restarts, "Restart Failures"
-              field :skipped, "Skipped"
-              field :pending, "Pending"
+        field :id, "Id"
+        field :host_name, "Host"
+        field :reported_at, "Reported at", Fields::Date
+        label "Report status" do
+          from "status" do
+            field :applied, "Applied"
+            field :restarted, "Restarted"
+            field :failed, "Failed"
+            field :failed_restarts, "Restart Failures"
+            field :skipped, "Skipped"
+            field :pending, "Pending"
+          end
+        end
+        label "Report metrics" do
+          from "metrics" do
+            from "time" do
+              field :config_retrieval, "config_retrieval"
+              field :exec, "exec"
+              field :file, "file"
+              field :package, "package"
+              field :service, "service"
+              field :user, "user"
+              field :yumrepo, "yumrepo"
+              field :filebucket, "filebucket"
+              field :cron, "cron"
+              field :total, "total"
             end
           end
-          label "Report metrics" do
-            from "metrics" do
-              from "time" do
-                field :config_retrieval, "config_retrieval"
-                field :exec, "exec"
-                field :file, "file"
-                field :package, "package"
-                field :service, "service"
-                field :user, "user"
-                field :yumrepo, "yumrepo"
-                field :filebucket, "filebucket"
-                field :cron, "cron"
-                field :total, "total"
-              end
+        end
+        field :logs, "Logs", Fields::Collection do
+          from :log do
+            from :source do
+              field :source, "Resource"
             end
-          end
-          field :logs, "Logs", Fields::Collection do
-            from :log do
-              from :source do
-                field :source, "Resource"
-              end
-              from :message do
-                field :message, "Message"
-              end
+            from :message do
+              field :message, "Message"
             end
           end
         end

--- a/lib/hammer_cli_foreman/smart_class_parameter.rb
+++ b/lib/hammer_cli_foreman/smart_class_parameter.rb
@@ -21,19 +21,19 @@ module HammerCLIForeman
       # FIXME: API returns doubled records, probably just if filtered by puppetclasses
       # it seems group by environment is missing
       # having the uniq to fix that
-      res["smart_class_parameters"].uniq 
+      HammerCLI::Output::RecordCollection.new(res.uniq, :meta => res.meta)
     end
   end
 
   class SmartClassParametersList < SmartClassParametersBriefList
 
-    output do 
+    output do
       from :puppetclass do
         field :name, "Puppet class"
         field :id, "Class Id", Fields::Id
       end
     end
-  end 
+  end
 
   class SmartClassParameter < HammerCLI::Apipie::Command
 
@@ -63,7 +63,7 @@ module HammerCLIForeman
             label  "Value" do
               field :id, 'Id'
               field :match, 'Match'
-              field :value, 'Value' 
+              field :value, 'Value'
             end
           end
         end
@@ -71,9 +71,8 @@ module HammerCLIForeman
         field :updated_at, "Updated at", Fields::Date
       end
 
-      def retrieve_data
-        res = super['smart_class_parameter']
-        res['override_value_order'] = res['override_value_order'].split("\n") 
+      def extend_data(res)
+        res['override_value_order'] = res['override_value_order'].split("\n")
         res['_environments'] = res['environments'].map { |e| e['environment']['name']}
         res['_environment_ids'] = res['environments'].map { |e| e['environment']['id']}
         res

--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -13,11 +13,9 @@ module HammerCLIForeman
 
       #FIXME: search by unknown type returns 500 from the server, propper error handling should resove this
       output do
-        from "smart_proxy" do
-          field :id, "Id"
-          field :name, "Name"
-          field :url, "URL"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :url, "URL"
       end
 
       apipie_options
@@ -28,18 +26,15 @@ module HammerCLIForeman
 
       action :show
 
-      def retrieve_data
-        sp = super
-        sp['smart_proxy']['_features'] = sp['smart_proxy']['features'].map { |f| f['feature']['name'] }
-        sp
+      output ListCommand.output_definition do
+        field :_features,  "Features",   Fields::List
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
-      output ListCommand.output_definition do
-        from "smart_proxy" do
-          field :_features,  "Features",   Fields::List
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+      def extend_data(proxy)
+        proxy['_features'] = proxy['features'].map { |f| f['feature']['name'] }
+        proxy
       end
 
     end
@@ -57,7 +52,7 @@ module HammerCLIForeman
 
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
-      
+
       action :update
 
       success_message "Smart proxy updated"
@@ -96,7 +91,6 @@ module HammerCLIForeman
         opts
       end
     end
-
 
     autoload_subcommands
   end

--- a/lib/hammer_cli_foreman/subnet.rb
+++ b/lib/hammer_cli_foreman/subnet.rb
@@ -9,12 +9,10 @@ module HammerCLIForeman
       resource ForemanApi::Resources::Subnet, "index"
 
       output do
-        from "subnet" do
-          field :id, "Id"
-          field :name, "Name"
-          field :network, "Network"
-          field :mask, "Mask"
-        end
+        field :id, "Id"
+        field :name, "Name"
+        field :network, "Network"
+        field :mask, "Mask"
       end
 
       apipie_options
@@ -26,21 +24,19 @@ module HammerCLIForeman
       resource ForemanApi::Resources::Subnet, "show"
 
       output ListCommand.output_definition do
-        from "subnet" do
-          field :priority, "Priority"
-          field :dns, "DNS", Fields::Server
-          field :dns_primary, "Primary DNS"
-          field :dns_secondary, "Secondary DNS"
-          field :domain_ids, "Domain ids", Fields::List
-          field :tftp, "TFTP", Fields::Server
-          field :tftp_id, "TFTP id"
-          field :dhcp, "DHCP", Fields::Server
-          field :dhcp_id, "DHCP id"
-          field :vlanid, "vlan id"
-          field :gateway, "Gateway"
-          field :from, "From"
-          field :to, "To"
-        end
+        field :priority, "Priority"
+        field :dns, "DNS", Fields::Server
+        field :dns_primary, "Primary DNS"
+        field :dns_secondary, "Secondary DNS"
+        field :domain_ids, "Domain ids", Fields::List
+        field :tftp, "TFTP", Fields::Server
+        field :tftp_id, "TFTP id"
+        field :dhcp, "DHCP", Fields::Server
+        field :dhcp_id, "DHCP id"
+        field :vlanid, "vlan id"
+        field :gateway, "Gateway"
+        field :from, "From"
+        field :to, "To"
       end
 
     end

--- a/lib/hammer_cli_foreman/user.rb
+++ b/lib/hammer_cli_foreman/user.rb
@@ -4,25 +4,21 @@ require 'hammer_cli_foreman/commands'
 
 module HammerCLIForeman
 
-  class User < HammerCLI::AbstractCommand
-    class ListCommand < HammerCLIForeman::ListCommand
-      resource ForemanApi::Resources::User, "index"
+  class User < HammerCLI::Apipie::Command
+    resource ForemanApi::Resources::User
 
-      def retrieve_data
-        data = super
-        data.map do |d|
-          d["user"]["full_name"] = [d["user"]["firstname"], d["user"]["lastname"]].join(' ')
-          d
-        end
-      end
+    class ListCommand < HammerCLIForeman::ListCommand
 
       output do
-        from "user" do
-          field :id, "Id"
-          field :login, "Login"
-          field :full_name, "Name"
-          field :mail, "Email"
-        end
+        field :id, "Id"
+        field :login, "Login"
+        field :full_name, "Name"
+        field :mail, "Email"
+      end
+
+      def extend_data(user)
+        user["full_name"] = [user["firstname"], user["lastname"]].join(' ')
+        user
       end
 
       apipie_options
@@ -31,21 +27,17 @@ module HammerCLIForeman
 
     class InfoCommand < HammerCLIForeman::InfoCommand
 
-      resource ForemanApi::Resources::User, "show"
       identifiers :id
 
-      def retrieve_data
-        data = super
-        data["user"]["full_name"] = [data["user"]["firstname"], data["user"]["lastname"]].join(' ')
-        data
+      output ListCommand.output_definition do
+        field :last_login_on, "Last login", Fields::Date
+        field :created_at, "Created at", Fields::Date
+        field :updated_at, "Updated at", Fields::Date
       end
 
-      output ListCommand.output_definition do
-        from "user" do
-          field :last_login_on, "Last login", Fields::Date
-          field :created_at, "Created at", Fields::Date
-          field :updated_at, "Updated at", Fields::Date
-        end
+      def extend_data(user)
+        user["full_name"] = [user["firstname"], user["lastname"]].join(' ')
+        user
       end
 
     end

--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -1,0 +1,79 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'hammer_cli'
+
+
+describe HammerCLIForeman do
+
+  context "collection_to_common_format" do
+
+    let(:kind) { { "name" => "PXELinux", "id" => 1 } }
+
+    it "should convert old API format" do
+      old_format = [
+        {
+          "template_kind" => kind
+        }
+      ]
+
+      set = HammerCLIForeman.collection_to_common_format(old_format)
+      set.must_be_kind_of HammerCLI::Output::RecordCollection
+      set.first.must_equal(kind)
+    end
+
+    it "should convert common API format" do
+      common_format = [ kind ]
+
+      set = HammerCLIForeman.collection_to_common_format(common_format)
+      set.must_be_kind_of HammerCLI::Output::RecordCollection
+      set.first.must_equal(kind)
+    end
+
+    it "should convert new API format" do
+      new_format = {
+        "total" => 1,
+        "subtotal" => 1,
+        "page" => 1,
+        "per_page" => 20,
+        "search" => nil,
+        "sort" => {
+          "by" => nil,
+          "order" => nil
+        },
+        "results" => [ kind ]
+      }
+
+      set = HammerCLIForeman.collection_to_common_format(new_format)
+      set.must_be_kind_of HammerCLI::Output::RecordCollection
+      set.first.must_equal(kind)
+    end
+
+    it "should rise error on unexpected format" do
+      proc { HammerCLIForeman.collection_to_common_format('unexpected') }.must_raise RuntimeError
+    end
+
+  end
+
+
+  context "record_to_common_format" do
+
+    let(:arch) { { "name" => "x86_64", "id" => 1 } }
+
+    it "should convert old API format" do
+      old_format = {
+        "architecture" => arch
+      }
+
+      rec = HammerCLIForeman.record_to_common_format(old_format)
+      rec.must_equal(arch)
+    end
+
+    it "should convert common API format" do
+      common_format = arch
+
+      rec = HammerCLIForeman.record_to_common_format(common_format)
+      rec.must_equal(arch)
+
+    end
+
+  end
+end

--- a/test/unit/output/formatters_test.rb
+++ b/test/unit/output/formatters_test.rb
@@ -9,11 +9,21 @@ describe HammerCLIForeman::Output::Formatters::OSNameFormatter do
     formatter = HammerCLIForeman::Output::Formatters::OSNameFormatter.new
     formatter.format({ :name => 'Fedora', :major => '19'}).must_equal 'Fedora 19'
   end
+
+  it "recovers when os is nil" do
+    formatter = HammerCLIForeman::Output::Formatters::OSNameFormatter.new
+    formatter.format(nil).must_equal nil
+  end
 end
 
 describe HammerCLIForeman::Output::Formatters::ServerFormatter do
   it "formats the server" do
     formatter = HammerCLIForeman::Output::Formatters::ServerFormatter.new
     formatter.format({ :name => 'Server', :url => "URL"}).must_equal 'Server (URL)'
+  end
+
+  it "recovers when server is nil" do
+    formatter = HammerCLIForeman::Output::Formatters::ServerFormatter.new
+    formatter.format(nil).must_equal nil
   end
 end

--- a/test/unit/test_output_adapter.rb
+++ b/test/unit/test_output_adapter.rb
@@ -3,7 +3,12 @@ require 'hammer_cli/output/adapter/abstract'
 
 class TestAdapter < HammerCLI::Output::Adapter::Abstract
 
-  def print_records(fields, data)
+  def print_record(fields, record)
+    print_collection(fields, [record].flatten(1))
+  end
+
+
+  def print_collection(fields, data)
     @separator = '#'
     puts @separator+fields.collect{|f| f.label.to_s}.join(@separator)+@separator
 


### PR DESCRIPTION
New API v2 brings new formats for responses. This update alow hammer to handle both the old and new style API responses. 
Make sure the https://github.com/theforeman/hammer-cli/pull/58 is merged first
