### PR TITLE
Extract commond requires and call it only once

### DIFF
--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -1,8 +1,7 @@
 require 'hammer_cli'
 require 'hammer_cli/exit_codes'
 
-require 'hammer_cli_foreman/version'
-require 'hammer_cli_foreman/output/fields'
+require 'foreman_api'
 
 module HammerCLIForeman
 
@@ -10,10 +9,15 @@ module HammerCLIForeman
     HammerCLIForeman::ExceptionHandler
   end
 
+  require 'hammer_cli_foreman/version'
   require 'hammer_cli_foreman/output'
+  require 'hammer_cli_foreman/commands'
+  require 'hammer_cli_foreman/associating_commands'
+  require 'hammer_cli_foreman/parameter'
   require 'hammer_cli_foreman/exception_handler'
-  require 'hammer_cli_foreman/architecture'
   require 'hammer_cli_foreman/common_parameter'
+
+  require 'hammer_cli_foreman/architecture'
   require 'hammer_cli_foreman/compute_resource'
   require 'hammer_cli_foreman/domain'
   require 'hammer_cli_foreman/environment'

--- a/lib/hammer_cli_foreman/architecture.rb
+++ b/lib/hammer_cli_foreman/architecture.rb
@@ -1,8 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/associating_commands'
-
 module HammerCLIForeman
 
   class Architecture < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/associating_commands.rb
+++ b/lib/hammer_cli_foreman/associating_commands.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
 module HammerCLIForeman
   module AssociatingCommands
 

--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -1,5 +1,3 @@
-require 'hammer_cli'
-
 module HammerCLIForeman
 
   def self.collection_to_common_format(data)

--- a/lib/hammer_cli_foreman/compute_resource.rb
+++ b/lib/hammer_cli_foreman/compute_resource.rb
@@ -1,6 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
 require 'hammer_cli_foreman/image'
 
 module HammerCLIForeman

--- a/lib/hammer_cli_foreman/domain.rb
+++ b/lib/hammer_cli_foreman/domain.rb
@@ -1,8 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/parameter'
-
 module HammerCLIForeman
 
   class Domain < HammerCLI::AbstractCommand

--- a/lib/hammer_cli_foreman/exceptions.rb
+++ b/lib/hammer_cli_foreman/exceptions.rb
@@ -1,5 +1,3 @@
-require 'hammer_cli_foreman/exceptions'
-
 module HammerCLIForeman
 
   class OperationNotSupportedError < StandardError; end

--- a/lib/hammer_cli_foreman/fact.rb
+++ b/lib/hammer_cli_foreman/fact.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
 module HammerCLIForeman
 
   class Fact < HammerCLI::AbstractCommand

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/parameter'
 require 'hammer_cli_foreman/report'
 require 'hammer_cli_foreman/puppet_class'
 require 'hammer_cli_foreman/smart_class_parameter'

--- a/lib/hammer_cli_foreman/hostgroup.rb
+++ b/lib/hammer_cli_foreman/hostgroup.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/parameter'
 require 'hammer_cli_foreman/smart_class_parameter'
 
 module HammerCLIForeman

--- a/lib/hammer_cli_foreman/image.rb
+++ b/lib/hammer_cli_foreman/image.rb
@@ -1,6 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
 require 'hammer_cli_foreman/compute_resource'
 
 module HammerCLIForeman

--- a/lib/hammer_cli_foreman/location.rb
+++ b/lib/hammer_cli_foreman/location.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/associating_commands'
 require 'hammer_cli_foreman/resource_supported_test'
 
 module HammerCLIForeman

--- a/lib/hammer_cli_foreman/media.rb
+++ b/lib/hammer_cli_foreman/media.rb
@@ -1,8 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/associating_commands'
-
 module HammerCLIForeman
 
   class Medium < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/model.rb
+++ b/lib/hammer_cli_foreman/model.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
 module HammerCLIForeman
 
   class Model < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/operating_system.rb
+++ b/lib/hammer_cli_foreman/operating_system.rb
@@ -1,8 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/associating_commands'
-
 module HammerCLIForeman
 
   class OperatingSystem < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/organization.rb
+++ b/lib/hammer_cli_foreman/organization.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/associating_commands'
 require 'hammer_cli_foreman/resource_supported_test'
 
 module HammerCLIForeman

--- a/lib/hammer_cli_foreman/output.rb
+++ b/lib/hammer_cli_foreman/output.rb
@@ -1,2 +1,2 @@
-require File.join(File.dirname(__FILE__), 'output/fields')
-require File.join(File.dirname(__FILE__), 'output/formatters')
+require 'hammer_cli_foreman/output/fields'
+require 'hammer_cli_foreman/output/formatters'

--- a/lib/hammer_cli_foreman/parameter.rb
+++ b/lib/hammer_cli_foreman/parameter.rb
@@ -1,7 +1,4 @@
-require 'hammer_cli'
 require 'hammer_cli/messages'
-require 'foreman_api'
-
 
 module HammerCLIForeman
 

--- a/lib/hammer_cli_foreman/partition_table.rb
+++ b/lib/hammer_cli_foreman/partition_table.rb
@@ -1,8 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/associating_commands'
-
 module HammerCLIForeman
 
   class PartitionTable < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/puppet_class.rb
+++ b/lib/hammer_cli_foreman/puppet_class.rb
@@ -1,6 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
 require 'hammer_cli_foreman/smart_class_parameter'
 
 module HammerCLIForeman

--- a/lib/hammer_cli_foreman/report.rb
+++ b/lib/hammer_cli_foreman/report.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
 module HammerCLIForeman
 
   class Report < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/smart_class_parameter.rb
+++ b/lib/hammer_cli_foreman/smart_class_parameter.rb
@@ -1,8 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
-
 module HammerCLIForeman
 
   class SmartClassParametersBriefList < HammerCLIForeman::ListCommand

--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
 module HammerCLIForeman
 
   class SmartProxy < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/subnet.rb
+++ b/lib/hammer_cli_foreman/subnet.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
 module HammerCLIForeman
 
   class Subnet < HammerCLI::AbstractCommand

--- a/lib/hammer_cli_foreman/template.rb
+++ b/lib/hammer_cli_foreman/template.rb
@@ -1,8 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-require 'hammer_cli_foreman/associating_commands'
-
 module HammerCLIForeman
 
   class Template < HammerCLI::Apipie::Command

--- a/lib/hammer_cli_foreman/user.rb
+++ b/lib/hammer_cli_foreman/user.rb
@@ -1,7 +1,3 @@
-require 'hammer_cli'
-require 'foreman_api'
-require 'hammer_cli_foreman/commands'
-
 module HammerCLIForeman
 
   class User < HammerCLI::Apipie::Command


### PR DESCRIPTION
It helps seeing what files are helpers and what are commands. Also, sooner or
later someone would forget to copy some requirement, but it would work,
because some other file already did that. And then, when the order of required
files changes (which just happened to us in hammer_cli_katello), it starts
failing.
