### PR TITLE
version bumps of hammer_cli and foreman_api

### DIFF
--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.license       = "GPL v3+"
 
   s.summary       = %q{Foreman commands for Hammer}
-  s.description   = <<EOF
-Foreman commands for Hammer CLI
+  s.description   = <<-EOF
+    Foreman commands for Hammer CLI
 EOF
 
 
@@ -24,10 +24,6 @@ EOF
   s.extra_rdoc_files = Dir['{doc}/**/*', 'README*']
   s.require_paths = ["lib"]
 
-  s.add_dependency 'hammer_cli', '= 0.0.15'
-  s.add_dependency 'foreman_api', '= 0.1.9'
-
-  # required for ruby < 1.9.0:
-  s.add_dependency 'mime-types', '< 2.0.0' #newer versions of mime-types are not 1.8 compatible
-
+  s.add_dependency 'hammer_cli', '0.0.17'
+  s.add_dependency 'foreman_api', '0.1.10'
 end

--- a/lib/hammer_cli_foreman/version.rb
+++ b/lib/hammer_cli_foreman/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIForeman
   def self.version
-    @version ||= Gem::Version.new '0.0.16'
+    @version ||= Gem::Version.new '0.0.17'
   end
 end


### PR DESCRIPTION
also no longer requiring `mime-types` because that's already required by
hammer-cli
- [ ] this pull-request first requires that theforeman/hammer-cli#74 be merged
  with a new gem version released.
- [ ] this pull-request first requires that theforeman/foreman_api#23 be
  merged with a new gem version released.

after the above gems are built, hopefully will build and release a new version `0.0.17` for `hammer_cli_katello` to consume.
