### PR TITLE
change name of per_page option in config file

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -62,7 +62,7 @@ module HammerCLIForeman
     def execute
       if respond_to?(:option_page) && respond_to?(:option_per_page)
         self.option_page ||= 1
-        self.option_per_page ||= HammerCLI::Settings.get(:ui, :option_per_page) || DEFAULT_PER_PAGE
+        self.option_per_page ||= HammerCLI::Settings.get(:ui, :per_page) || DEFAULT_PER_PAGE
         browse_collection
       else
         retrieve_and_print


### PR DESCRIPTION
with this I can have

```
:ui:
  :per_page: 100
```

instead of

```
:ui:
  :option_per_page: 100
```
