### PR TITLE
fixes #4358 - unmanaged host can be now created empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage
 # rvm/rbenv
 .ruby-gemset
 .ruby-version
+
+# Editors
+tags

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -298,11 +298,17 @@ module HammerCLIForeman
 
       include HammerCLIForeman::CommonHostUpdateOptions
 
-      validate_options do
-        unless option(:option_hostgroup_id).exist?
-          all(:option_environment_id, :option_architecture_id, :option_domain_id,
-            :option_puppet_proxy_id, :option_operatingsystem_id,
-            :option_partition_table_id).required
+      def validate_options
+        super
+        unless validator.option(:option_hostgroup_id).exist?
+          if option_managed
+            validator.all(:option_environment_id, :option_architecture_id, :option_domain_id,
+                          :option_puppet_proxy_id, :option_operatingsystem_id,
+                          :option_partition_table_id).required
+          else
+            # unmanaged host only requires environment
+            validator.option(:option_environment_id).required
+          end
         end
       end
     end


### PR DESCRIPTION
To test:

```
hammer host create --managed false --environment-id 1 --name unmanaged2.blah
```
