### PR TITLE
Fixed Error: undefined method `[]' for nil:NilClass

### DIFF
--- a/lib/hammer_cli_foreman/smart_class_parameter.rb
+++ b/lib/hammer_cli_foreman/smart_class_parameter.rb
@@ -69,8 +69,8 @@ module HammerCLIForeman
 
       def extend_data(res)
         res['override_value_order'] = res['override_value_order'].split("\n")
-        res['_environments'] = res['environments'].map { |e| e['environment']['name']}
-        res['_environment_ids'] = res['environments'].map { |e| e['environment']['id']}
+        res['_environments'] = res['environments'].map { |e| e['name']}
+        res['_environment_ids'] = res['environments'].map { |e| e['id']}
         res
       end
 


### PR DESCRIPTION
This error is similar to what is the problem in https://github.com/theforeman/hammer-cli-foreman/pull/90 with the only difference that there is no rescue which hides the error.

Removed the nesting to solve the issue.
