### PR TITLE
Fixes #4516

### DIFF
--- a/lib/hammer_cli_foreman/template.rb
+++ b/lib/hammer_cli_foreman/template.rb
@@ -41,7 +41,7 @@ module HammerCLIForeman
         else
           tpl["type"] = tpl["template_kind"]["name"] if tpl["template_kind"]
         end
-        tpl['operatingsystem_ids'] = tpl['operatingsystems'].map { |os| os['id'] }
+        tpl['operatingsystem_ids'] = tpl['operatingsystems'].map { |os| os['id'] } rescue []
         tpl
       end
 


### PR DESCRIPTION
template info error if no associated OS ids are present

http://projects.theforeman.org/issues/4516
