### PR TITLE
Fixes #3970 - Adds OS default templates

### DIFF
--- a/test/unit/operating_system_test.rb
+++ b/test/unit/operating_system_test.rb
@@ -60,6 +60,7 @@ describe HammerCLIForeman::OperatingSystem do
         it_should_print_column "Architectures"
         it_should_print_column "Partition tables"
         it_should_print_column "Config templates"
+        it_should_print_column "Default OS templates"
         it_should_print_column "Parameters"
       end
     end


### PR DESCRIPTION
Adds support for OS default templates. 

Adds two commands - set-default-template and delete-default-template - to the os main command. 
