### PR TITLE
fixes #4589 - adds conditional output field to show network interfaces

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -120,6 +120,10 @@ module HammerCLIForeman
       def extend_data(host)
         host["environment_name"] = host["environment"]["environment"]["name"] rescue nil
         host["parameters"] = HammerCLIForeman::Parameter.get_parameters(resource_config, :host, host)
+        host["_bmc_interfaces"] =
+          host["interfaces"].select{|intfs| intfs["type"] == "Nic::BMC" } rescue []
+        host["_managed_interfaces"] =
+          host["interfaces"].select{|intfs| intfs["type"] == "Nic::Managed" } rescue []
         host
       end
 
@@ -167,6 +171,31 @@ module HammerCLIForeman
         collection :parameters, "Parameters" do
           field nil, nil, Fields::KeyValue
         end
+
+        collection :_bmc_interfaces, "BMC Network Interfaces", :hide_blank => true do
+          field :id, "Id"
+          field :name, "Name"
+          field :ip, "IP"
+          field :mac, "MAC"
+          field :domain_id, "Domain Id"
+          field :domain_name, "Domain Name"
+          field :subnet_id, "Subnet Id"
+          field :subnet_name, "Subnet Name"
+          field :username, "BMC Username"
+          field :password, "BMC Password"
+        end
+
+        collection :_managed_interfaces, "Managed Network Interfaces", :hide_blank => true do
+          field :id, "Id"
+          field :name, "Name"
+          field :ip, "IP"
+          field :mac, "MAC"
+          field :domain_id, "Domain Id"
+          field :domain_name, "Domain Name"
+          field :subnet_id, "Subnet Id"
+          field :subnet_name, "Subnet Name"
+        end
+
       end
 
       apipie_options

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -57,6 +57,7 @@ describe HammerCLIForeman::Host do
         it_should_print_columns ["Created at", "Updated at", "Installed at", "Last report"]
         it_should_print_columns ["Puppet CA Proxy Id", "Medium Id", "Model Id", "Owner Id", "Subnet Id", "Domain Id"]
         it_should_print_columns ["Puppet Proxy Id", "Owner Type", "Partition Table Id", "Architecture Id", "Image Id", "Compute Resource Id"]
+        it_should_print_columns ["BMC Network Interfaces", "Managed Network Interfaces"]
         it_should_print_columns ["Comment"]
       end
     end


### PR DESCRIPTION
Fixes http://projects.theforeman.org/issues/4589

I discussed with @tstrachota to make those lists additional as compute resources do not have them. 

I split up managed- and BMC-interfaces as BMC interfaces have the additional username/password fields. I didn't want to make them `:hide_blank => true` as a blank username/password could be a valid option. 
I found no way to properly factor this into one basic call + the additional options in the BMC collection. Any ideas?
