### PR TITLE
refs #4572 - unable to delete parameter

### DIFF
--- a/lib/hammer_cli_foreman/parameter.rb
+++ b/lib/hammer_cli_foreman/parameter.rb
@@ -87,6 +87,7 @@ module HammerCLIForeman
     class DeleteCommand < HammerCLI::Apipie::Command
 
       include HammerCLI::Messages
+      include HammerCLIForeman::ConnectionSetup
 
       option "--name", "NAME", _("parameter name"), :required => true
 


### PR DESCRIPTION
Issue #4572 affected also deleting. I didn't fix it in the first PR.
