### PR TITLE
Add provision_method to host creation

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -56,6 +56,8 @@ module HammerCLIForeman
         :format => HammerCLI::Options::Normalizers::KeyValueList.new
       base.option "--interface", "INTERFACE", _("Interface parameters."), :multivalued => true,
         :format => HammerCLI::Options::Normalizers::KeyValueList.new
+      base.option "--provision_method", "METHOD", " ",
+        :format => HammerCLI::Options::Normalizers::Enum.new(['build', 'image'])
     end
 
     def self.ask_password


### PR DESCRIPTION
This is necessary as libvirt (and ovirt) hosts can now use either "build" or "image" methods.
