### PR TITLE
Fixes #4849 - Hammer fails silently when no cache is generated

### DIFF
--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -13,34 +13,42 @@ module HammerCLIForeman
   require 'hammer_cli_foreman/version'
   require 'hammer_cli_foreman/output'
   require 'hammer_cli_foreman/credentials'
-  require 'hammer_cli_foreman/commands'
-  require 'hammer_cli_foreman/associating_commands'
-  require 'hammer_cli_foreman/parameter'
   require 'hammer_cli_foreman/exception_handler'
-  require 'hammer_cli_foreman/common_parameter'
 
-  require 'hammer_cli_foreman/architecture'
-  require 'hammer_cli_foreman/auth'
-  require 'hammer_cli_foreman/compute_resource'
-  require 'hammer_cli_foreman/domain'
-  require 'hammer_cli_foreman/environment'
-  require 'hammer_cli_foreman/fact'
-  require 'hammer_cli_foreman/host'
-  require 'hammer_cli_foreman/hostgroup'
-  require 'hammer_cli_foreman/location'
-  require 'hammer_cli_foreman/media'
-  require 'hammer_cli_foreman/model'
-  require 'hammer_cli_foreman/operating_system'
-  require 'hammer_cli_foreman/organization'
-  require 'hammer_cli_foreman/output/fields'
-  require 'hammer_cli_foreman/partition_table'
-  require 'hammer_cli_foreman/report'
-  require 'hammer_cli_foreman/puppet_class'
-  require 'hammer_cli_foreman/smart_proxy'
-  require 'hammer_cli_foreman/smart_class_parameter'
-  require 'hammer_cli_foreman/subnet'
-  require 'hammer_cli_foreman/template'
-  require 'hammer_cli_foreman/user'
+  begin
+    require 'hammer_cli_foreman/commands'
+    require 'hammer_cli_foreman/associating_commands'
+    require 'hammer_cli_foreman/parameter'
+    require 'hammer_cli_foreman/common_parameter'
+
+    require 'hammer_cli_foreman/architecture'
+    require 'hammer_cli_foreman/auth'
+    require 'hammer_cli_foreman/compute_resource'
+    require 'hammer_cli_foreman/domain'
+    require 'hammer_cli_foreman/environment'
+    require 'hammer_cli_foreman/fact'
+    require 'hammer_cli_foreman/host'
+    require 'hammer_cli_foreman/hostgroup'
+    require 'hammer_cli_foreman/location'
+    require 'hammer_cli_foreman/media'
+    require 'hammer_cli_foreman/model'
+    require 'hammer_cli_foreman/operating_system'
+    require 'hammer_cli_foreman/organization'
+    require 'hammer_cli_foreman/output/fields'
+    require 'hammer_cli_foreman/partition_table'
+    require 'hammer_cli_foreman/report'
+    require 'hammer_cli_foreman/puppet_class'
+    require 'hammer_cli_foreman/smart_proxy'
+    require 'hammer_cli_foreman/smart_class_parameter'
+    require 'hammer_cli_foreman/subnet'
+    require 'hammer_cli_foreman/template'
+    require 'hammer_cli_foreman/user'
+
+  rescue => e
+    handler = HammerCLIForeman::ExceptionHandler.new(:context => {}, :adapter => :base)
+    handler.handle_exception(e)
+    raise HammerCLI::ModuleLoadingError.new(e)
+  end
 
 end
 

--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -70,5 +70,14 @@ module HammerCLIForeman
       log_full_error e
     end
 
+    def handle_apipie_docloading_error(e)
+      rake_command = 'foreman-rake apipie:cache'
+      print_error _("Could not load API description from the server\n"\
+          "  - is your server down?\n"\
+          "  - was \"#{rake_command}\" run on the server when using apipie cache? (typical production settings))\n")
+      log_full_error e
+      HammerCLI::EX_CONFIG
+    end
+
   end
 end


### PR DESCRIPTION
This is the foreman part. I'm trying to catch and handle the exception with the exception handler. It is then re-raised for hammer to behave consistently. I was thinking about raising `HammerCLI::ModuleLoadException` instead, to not have the same error in the logs twice, any comments?

The core changes - https://github.com/theforeman/hammer-cli/pull/100
