### PR TITLE
Fixes #5209 - setting infinite timeouts

### DIFF
--- a/config/foreman.yml
+++ b/config/foreman.yml
@@ -12,5 +12,5 @@
   # Check API documentation cache status on each request
   #:refresh_cache: false
 
-  # API request timeout, set 0 for infinity
+  # API request timeout, set -1 for infinity
   #:request_timeout: 120 #seconds

--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -26,5 +26,6 @@ EOF
 
   s.add_dependency 'hammer_cli', '>= 0.1.0'
   s.add_dependency 'apipie-bindings', '>= 0.0.6'
+  s.add_dependency 'rest-client', '>= 1.6.5' # lower versions don't allow setting infinite timeouts
 
 end

--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -19,7 +19,7 @@ module HammerCLIForeman
     config[:aggressive_cache_checking] = HammerCLI::Settings.get(:foreman, :refresh_cache) || true
     config[:headers] = { "Accept-Language" => HammerCLI::I18n.locale }
     config[:timeout] = HammerCLI::Settings.get(:foreman, :request_timeout)
-    config[:timeout] = 0 if (config[:timeout] && config[:timeout].to_i < 0)
+    config[:timeout] = -1 if (config[:timeout] && config[:timeout].to_i < 0)
     config
   end
 


### PR DESCRIPTION
I found out that timeout behaviour differs across versions of ruby and rest-client. Using rest-client >= 1.6.5 should be safe with any version of ruby.
