### PR TITLE
Refs #5598 - fancy names for all id options

### DIFF
--- a/lib/hammer_cli_foreman/exceptions.rb
+++ b/lib/hammer_cli_foreman/exceptions.rb
@@ -2,6 +2,10 @@ module HammerCLIForeman
 
   class OperationNotSupportedError < StandardError; end
 
+  # Resolver exceptions
+  class ResolverError < StandardError; end
+  class MissingSeachOptions < ResolverError; end
+
 end
 
 

--- a/test/unit/helpers/command.rb
+++ b/test/unit/helpers/command.rb
@@ -13,12 +13,12 @@ class IdResolverTestProxy
     @original_resolver.scoped_options(scope, options)
   end
 
-  def dependent_resources(resource)
-    @original_resolver.dependent_resources(resource)
+  def dependent_resources(resource, options={})
+    @original_resolver.dependent_resources(resource, options)
   end
 
-  def required_id_params(action)
-    @original_resolver.required_id_params(action)
+  def id_params(action, options={})
+    @original_resolver.id_params(action, options)
   end
 
   def param_to_resource(param_name)


### PR DESCRIPTION
Option generators created searchable options only for required id parameters. This patch updates resolver to enable searches for all id parameters.
Commands now build searchable options for all id parameters of it's main resource and required id parameters of the dependent resources.
