### PR TITLE
Refs #4478 - support for API lacalization

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -18,6 +18,7 @@ module HammerCLIForeman
     config[:api_version] = 2
     config[:aggressive_cache_checking] = HammerCLI::Settings.get(:foreman, :refresh_cache) || true
     config[:headers] = { "Accept-Language" => HammerCLI::I18n.locale }
+    config[:language] = HammerCLI::I18n.locale
     config[:timeout] = HammerCLI::Settings.get(:foreman, :request_timeout)
     config[:timeout] = -1 if (config[:timeout] && config[:timeout].to_i < 0)
     config


### PR DESCRIPTION
Makes hammer ask for localized bindings:

```
LANG=cs bundle exec hammer -d -c ~/.hammer/test.yml os list
```

In the logs you should find:

```
[ INFO 2014-05-20 01:26:15 API] GET /apidoc/v2.cs.json
```
