### PR TITLE
Fixes #6073 - search opts not built id-less params

### DIFF
--- a/lib/hammer_cli_foreman/option_builders.rb
+++ b/lib/hammer_cli_foreman/option_builders.rb
@@ -69,8 +69,9 @@ module HammerCLIForeman
 
       dependent_resources = []
 
+      builders << SearchablesOptionBuilder.new(resource, @searchables)
+
       if action.params.find{ |p| p.name == "id" }
-        builders << SearchablesOptionBuilder.new(resource, @searchables)
         dependent_resources += @dependency_resolver.resource_dependencies(resource, :only_required => true, :recursive => true)
       end
 


### PR DESCRIPTION
Searchable options are not being build for commands that with actions
that do not have an param named id. This commit allows the searchable
options to be built without the action needing to define param :id.
