### PR TITLE
#6335, #6343 - host creation improvements

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -323,7 +323,7 @@ module HammerCLIForeman
 
       def validate_options
         super
-        unless validator.option(:option_hostgroup_id).exist?
+        unless validator.any(:option_hostgroup_id, :option_hostgroup_name).exist?
           if option_managed
             validator.all(:option_environment_id, :option_architecture_id, :option_domain_id,
                           :option_puppet_proxy_id, :option_operatingsystem_id,

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -221,6 +221,8 @@ describe HammerCLIForeman::Host do
           ["--name=host", "--environment-id=1", "--architecture-id=1", "--domain-id=1", "--operatingsystem-id=1"]
       it_should_fail_with "operatingsystem_id missing",
           ["--name=host", "--environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1"]
+      it_should_accept "only hostgroup name", ["--hostgroup=example"]
+      it_should_accept "only hostgroup ID", ["--hostgroup-id=example"]
 
       with_params ["--name=host", "--environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1", "--operatingsystem-id=1",
             "--ip=1.2.3.4", "--mac=11:22:33:44:55:66", "--medium-id=1", "--partition-table-id=1", "--subnet-id=1",


### PR DESCRIPTION
I'm trying to make this work:

```
hammer host create --hostgroup libvirt --compute-resource localhost --name hammer
```

It nearly does, only http://projects.theforeman.org/issues/6342 is a problem because of Hammer passing in the keys below compute_attributes (#4250 fixed the API issue itself with compute profiles, meaning if you don't pass compute_attributes at all, or it's empty, then you can create a host entirely from a profile).
