### PR TITLE
ref #6203 - creating a more generic hook for search_options, BZ1108905

### DIFF
--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -141,7 +141,12 @@ module HammerCLIForeman
     end
 
     def search_options(options, resource)
-      search_options = create_search_options(options, resource)
+      method = "create_#{resource.name}_search_options"
+      search_options = if respond_to?(method)
+                         send(method, options)
+                       else
+                         create_search_options(options, resource)
+                       end
       raise MissingSeachOptions.new(_("Missing options to search %s") % resource.singular_name) if search_options.empty?
       search_options
     end


### PR DESCRIPTION
**please note** that `resource.name` is the pluralized name of the resource so that if you want to create your own `search_options` hook, make sure your method name contains the pluralized resource.
