### PR TITLE
fixes #6478 - obey refresh_cache default of false

### DIFF
--- a/doc/developer_docs.md
+++ b/doc/developer_docs.md
@@ -8,3 +8,5 @@ Studying it first can help you to understand the basic principles.
 Foreman plugin extends the Hammer Core in following areas:
  - [Building options](option_builder.md#option-builder)
 
+It's recommended that you set `:refresh_cache: true` in the plugin settings if
+engaging in API development to enable aggressive apidoc cache checking.

--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -19,7 +19,7 @@ module HammerCLIForeman
     config[:credentials] = credentials
     config[:logger] = Logging.logger['API']
     config[:api_version] = 2
-    config[:aggressive_cache_checking] = HammerCLI::Settings.get(:foreman, :refresh_cache) || true
+    config[:aggressive_cache_checking] = HammerCLI::Settings.get(:foreman, :refresh_cache) || false
     config[:headers] = { "Accept-Language" => HammerCLI::I18n.locale }
     config[:language] = HammerCLI::I18n.locale
     config[:timeout] = HammerCLI::Settings.get(:foreman, :request_timeout)


### PR DESCRIPTION
`|| true` meant that setting refresh_cache to false would cause :aggressive_cache_checking to become true.
