### PR TITLE
Fixes #6766 - Pagination is failing

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -221,7 +221,7 @@ module HammerCLIForeman
 
     def execute
       if respond_to?(:option_page) && respond_to?(:option_per_page)
-        self.option_page ||= 1
+        self.option_page = (self.option_page || 1).to_i
         self.option_per_page ||= HammerCLI::Settings.get(:ui, :per_page) || DEFAULT_PER_PAGE
         browse_collection
       else


### PR DESCRIPTION
```
# hammer activation-key list --organization-label='ACME_Corporation' --page=1 --per-page=2
---|--------|----------------|-----------------------|-------------
ID | NAME   | CONSUMED       | LIFECYCLE ENVIRONMENT | CONTENT VIEW
---|--------|----------------|-----------------------|-------------
5  | actkey | 0 of Unlimited |                       |             
8  | ak1234 | 0 of Unlimited |                       | cv1         
---|--------|----------------|-----------------------|-------------
List next page? (Y/n): Y
Error: can't convert Fixnum into String
```

Applicable for any list command
