### PR TITLE
Fixes #6761 - lazy loaded subcommands

### DIFF
--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -12,6 +12,7 @@ module HammerCLIForeman
 
   require 'hammer_cli_foreman/version'
   require 'hammer_cli_foreman/output'
+  require 'hammer_cli_foreman/output/fields'
   require 'hammer_cli_foreman/credentials'
   require 'hammer_cli_foreman/exception_handler'
   require 'hammer_cli_foreman/option_builders'
@@ -26,31 +27,102 @@ module HammerCLIForeman
     require 'hammer_cli_foreman/parameter'
     require 'hammer_cli_foreman/common_parameter'
 
-    require 'hammer_cli_foreman/architecture'
-    require 'hammer_cli_foreman/auth'
-    require 'hammer_cli_foreman/compute_resource'
-    require 'hammer_cli_foreman/domain'
-    require 'hammer_cli_foreman/environment'
-    require 'hammer_cli_foreman/fact'
-    require 'hammer_cli_foreman/filter'
-    require 'hammer_cli_foreman/host'
-    require 'hammer_cli_foreman/hostgroup'
-    require 'hammer_cli_foreman/location'
-    require 'hammer_cli_foreman/media'
-    require 'hammer_cli_foreman/model'
-    require 'hammer_cli_foreman/operating_system'
-    require 'hammer_cli_foreman/organization'
-    require 'hammer_cli_foreman/output/fields'
-    require 'hammer_cli_foreman/partition_table'
-    require 'hammer_cli_foreman/report'
-    require 'hammer_cli_foreman/puppet_class'
-    require 'hammer_cli_foreman/role'
-    require 'hammer_cli_foreman/smart_proxy'
-    require 'hammer_cli_foreman/smart_class_parameter'
-    require 'hammer_cli_foreman/subnet'
-    require 'hammer_cli_foreman/template'
-    require 'hammer_cli_foreman/user'
-    require 'hammer_cli_foreman/usergroup'
+    HammerCLI::MainCommand.lazy_subcommand('auth', _("Foreman connection login/logout."),
+      'HammerCLIForeman::Auth', 'hammer_cli_foreman/auth'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('architecture', _("Manipulate architectures."),
+      'HammerCLIForeman::Architecture', 'hammer_cli_foreman/architecture'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('compute-resource', _("Manipulate compute resources."),
+      'HammerCLIForeman::ComputeResource', 'hammer_cli_foreman/compute_resource'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('domain', _("Manipulate domains."),
+      'HammerCLIForeman::Domain', 'hammer_cli_foreman/domain'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('environment', _("Manipulate environments."),
+      'HammerCLIForeman::Environment', 'hammer_cli_foreman/environment'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('fact', _("Search facts."),
+      'HammerCLIForeman::Fact', 'hammer_cli_foreman/fact'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('filter', _("Manage permission filters."),
+      'HammerCLIForeman::Filter', 'hammer_cli_foreman/filter'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('host', _("Manipulate hosts."),
+      'HammerCLIForeman::Host', 'hammer_cli_foreman/host'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('hostgroup', _("Manipulate hostgroups."),
+      'HammerCLIForeman::Hostgroup', 'hammer_cli_foreman/hostgroup'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('location', _("Manipulate locations."),
+      'HammerCLIForeman::Location', 'hammer_cli_foreman/location'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('medium', _("Manipulate installation media."),
+      'HammerCLIForeman::Medium', 'hammer_cli_foreman/media'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('model', _("Manipulate hardware models."),
+      'HammerCLIForeman::Model', 'hammer_cli_foreman/model'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('os', _("Manipulate operating system."),
+      'HammerCLIForeman::OperatingSystem', 'hammer_cli_foreman/operating_system'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('organization', _("Manipulate organizations."),
+      'HammerCLIForeman::Organization', 'hammer_cli_foreman/organization'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('partition-table', _("Manipulate partition tables."),
+      'HammerCLIForeman::PartitionTable', 'hammer_cli_foreman/partition_table'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('puppet-class', _("Search puppet modules."),
+      'HammerCLIForeman::PuppetClass', 'hammer_cli_foreman/puppet_class'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('report', _("Browse and read reports."),
+      'HammerCLIForeman::Report', 'hammer_cli_foreman/report'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('role', _("Manage user roles."),
+      'HammerCLIForeman::Role', 'hammer_cli_foreman/role'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('sc-param', _("Manipulate smart class parameters."),
+      'HammerCLIForeman::SmartClassParameter', 'hammer_cli_foreman/smart_class_parameter'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('proxy', _("Manipulate smart proxies."),
+      'HammerCLIForeman::SmartProxy', 'hammer_cli_foreman/smart_proxy'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('subnet', _("Manipulate subnets."),
+      'HammerCLIForeman::Subnet', 'hammer_cli_foreman/subnet'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('template', _("Manipulate config templates."),
+      'HammerCLIForeman::Template', 'hammer_cli_foreman/template'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('user', _("Manipulate users."),
+      'HammerCLIForeman::User', 'hammer_cli_foreman/user'
+    )
+
+    HammerCLI::MainCommand.lazy_subcommand('user-group', _("Manage user groups."),
+      'HammerCLIForeman::Usergroup', 'hammer_cli_foreman/usergroup'
+    )
+
 
   rescue => e
     handler = HammerCLIForeman::ExceptionHandler.new(:context => {}, :adapter => :base)

--- a/lib/hammer_cli_foreman/architecture.rb
+++ b/lib/hammer_cli_foreman/architecture.rb
@@ -57,5 +57,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'architecture', _("Manipulate architectures."), HammerCLIForeman::Architecture
 

--- a/lib/hammer_cli_foreman/auth.rb
+++ b/lib/hammer_cli_foreman/auth.rb
@@ -45,5 +45,4 @@ module HammerCLIForeman
     autoload_subcommands
   end
 
-  HammerCLI::ShellMainCommand.subcommand 'auth', _("Foreman connection login/logout."), HammerCLIForeman::Auth
 end

--- a/lib/hammer_cli_foreman/compute_resource.rb
+++ b/lib/hammer_cli_foreman/compute_resource.rb
@@ -92,6 +92,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'compute-resource', _("Manipulate compute resources."), HammerCLIForeman::ComputeResource
-
 

--- a/lib/hammer_cli_foreman/domain.rb
+++ b/lib/hammer_cli_foreman/domain.rb
@@ -93,5 +93,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'domain', _("Manipulate domains."), HammerCLIForeman::Domain
 

--- a/lib/hammer_cli_foreman/environment.rb
+++ b/lib/hammer_cli_foreman/environment.rb
@@ -63,5 +63,3 @@ module HammerCLIForeman
   end
 
 end
-
-HammerCLI::MainCommand.subcommand 'environment', _("Manipulate environments."), HammerCLIForeman::Environment

--- a/lib/hammer_cli_foreman/fact.rb
+++ b/lib/hammer_cli_foreman/fact.rb
@@ -33,4 +33,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'fact', _("Search facts."), HammerCLIForeman::Fact
+

--- a/lib/hammer_cli_foreman/filter.rb
+++ b/lib/hammer_cli_foreman/filter.rb
@@ -98,5 +98,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'filter', _("Manage permission filters."), HammerCLIForeman::Filter
+
 

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -466,5 +466,3 @@ module HammerCLIForeman
   end
 
 end
-
-HammerCLI::MainCommand.subcommand 'host', _("Manipulate hosts."), HammerCLIForeman::Host

--- a/lib/hammer_cli_foreman/hostgroup.rb
+++ b/lib/hammer_cli_foreman/hostgroup.rb
@@ -1,4 +1,5 @@
 require 'hammer_cli_foreman/smart_class_parameter'
+require 'hammer_cli_foreman/puppet_class'
 
 module HammerCLIForeman
 
@@ -138,4 +139,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'hostgroup', _("Manipulate hostgroups."), HammerCLIForeman::Hostgroup
+

--- a/lib/hammer_cli_foreman/image.rb
+++ b/lib/hammer_cli_foreman/image.rb
@@ -1,4 +1,3 @@
-require 'hammer_cli_foreman/compute_resource'
 
 module HammerCLIForeman
 

--- a/lib/hammer_cli_foreman/location.rb
+++ b/lib/hammer_cli_foreman/location.rb
@@ -97,5 +97,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'location', _("Manipulate locations."), HammerCLIForeman::Location
+
 

--- a/lib/hammer_cli_foreman/media.rb
+++ b/lib/hammer_cli_foreman/media.rb
@@ -61,5 +61,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'medium', _("Manipulate installation media."), HammerCLIForeman::Medium
+
 

--- a/lib/hammer_cli_foreman/model.rb
+++ b/lib/hammer_cli_foreman/model.rb
@@ -55,5 +55,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'model', _("Manipulate hardware models."), HammerCLIForeman::Model
+
 

--- a/lib/hammer_cli_foreman/operating_system.rb
+++ b/lib/hammer_cli_foreman/operating_system.rb
@@ -244,5 +244,3 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'os', _("Manipulate operating system."), HammerCLIForeman::OperatingSystem
-

--- a/lib/hammer_cli_foreman/organization.rb
+++ b/lib/hammer_cli_foreman/organization.rb
@@ -98,5 +98,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'organization', _("Manipulate organizations."), HammerCLIForeman::Organization
+
 

--- a/lib/hammer_cli_foreman/partition_table.rb
+++ b/lib/hammer_cli_foreman/partition_table.rb
@@ -77,4 +77,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'partition-table', _("Manipulate partition tables."), HammerCLIForeman::PartitionTable
+

--- a/lib/hammer_cli_foreman/puppet_class.rb
+++ b/lib/hammer_cli_foreman/puppet_class.rb
@@ -57,5 +57,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'puppet-class', _("Search puppet modules."), HammerCLIForeman::PuppetClass
+
 

--- a/lib/hammer_cli_foreman/report.rb
+++ b/lib/hammer_cli_foreman/report.rb
@@ -85,5 +85,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'report', _("Browse and read reports."), HammerCLIForeman::Report
+
 

--- a/lib/hammer_cli_foreman/role.rb
+++ b/lib/hammer_cli_foreman/role.rb
@@ -1,3 +1,5 @@
+require 'hammer_cli_foreman/filter'
+
 module HammerCLIForeman
 
   class Role < HammerCLIForeman::Command
@@ -72,5 +74,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'role', _("Manage user roles."), HammerCLIForeman::Role
+
 

--- a/lib/hammer_cli_foreman/smart_class_parameter.rb
+++ b/lib/hammer_cli_foreman/smart_class_parameter.rb
@@ -104,6 +104,6 @@ module HammerCLIForeman
 
   end
 
-  HammerCLI::MainCommand.subcommand 'sc-param', _("Manipulate smart class parameters."), HammerCLIForeman::SmartClassParameter
+
 
 end

--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -100,4 +100,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'proxy', _("Manipulate smart proxies."), HammerCLIForeman::SmartProxy
+

--- a/lib/hammer_cli_foreman/subnet.rb
+++ b/lib/hammer_cli_foreman/subnet.rb
@@ -70,5 +70,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'subnet', _("Manipulate subnets."), HammerCLIForeman::Subnet
+
 

--- a/lib/hammer_cli_foreman/template.rb
+++ b/lib/hammer_cli_foreman/template.rb
@@ -151,5 +151,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'template', _("Manipulate config templates."), HammerCLIForeman::Template
+
 

--- a/lib/hammer_cli_foreman/user.rb
+++ b/lib/hammer_cli_foreman/user.rb
@@ -73,4 +73,4 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'user', _("Manipulate users."), HammerCLIForeman::User
+

--- a/lib/hammer_cli_foreman/usergroup.rb
+++ b/lib/hammer_cli_foreman/usergroup.rb
@@ -54,5 +54,5 @@ module HammerCLIForeman
 
 end
 
-HammerCLI::MainCommand.subcommand 'user-group', _("Manage user groups."), HammerCLIForeman::Usergroup
+
 

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/architecture'
 
 describe HammerCLIForeman::Architecture do
 

--- a/test/unit/common_parameter_test.rb
+++ b/test/unit/common_parameter_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/common_parameter'
 
 describe HammerCLIForeman::CommonParameter do
 

--- a/test/unit/compute_resource_test.rb
+++ b/test/unit/compute_resource_test.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 require File.join(File.dirname(__FILE__), 'test_output_adapter')
 
+require 'hammer_cli_foreman/compute_resource'
 
 describe HammerCLIForeman::ComputeResource do
 

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/domain'
 
 describe HammerCLIForeman::Domain do
 

--- a/test/unit/environment_test.rb
+++ b/test/unit/environment_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/environment'
 
 describe HammerCLIForeman::Environment do
 

--- a/test/unit/fact_test.rb
+++ b/test/unit/fact_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/fact'
 
 describe HammerCLIForeman::Fact do
 

--- a/test/unit/filter_test.rb
+++ b/test/unit/filter_test.rb
@@ -1,6 +1,8 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/filter'
+
 describe HammerCLIForeman::Filter do
 
   include CommandTestHelper

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/host'
 
 describe HammerCLIForeman::Host do
 

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/hostgroup'
 
 describe HammerCLIForeman::Hostgroup do
 

--- a/test/unit/image_test.rb
+++ b/test/unit/image_test.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 require File.join(File.dirname(__FILE__), 'test_output_adapter')
 
-
+require 'hammer_cli_foreman/image'
 
 describe HammerCLIForeman::Image do
 

--- a/test/unit/location_test.rb
+++ b/test/unit/location_test.rb
@@ -1,6 +1,8 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'helpers/resource_disabled')
 
+require 'hammer_cli_foreman/location'
+
 describe HammerCLIForeman::Location do
 
   include CommandTestHelper

--- a/test/unit/media_test.rb
+++ b/test/unit/media_test.rb
@@ -1,6 +1,8 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/media'
+
 describe HammerCLIForeman::Medium do
 
   include CommandTestHelper

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/model'
 
 describe HammerCLIForeman::Model do
 

--- a/test/unit/operating_system_test.rb
+++ b/test/unit/operating_system_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/operating_system'
 
 describe HammerCLIForeman::OperatingSystem do
 

--- a/test/unit/organization_test.rb
+++ b/test/unit/organization_test.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'helpers/resource_disabled')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/organization'
 
 describe HammerCLIForeman::Organization do
 

--- a/test/unit/partition_table_test.rb
+++ b/test/unit/partition_table_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/partition_table'
 
 describe HammerCLIForeman::PartitionTable do
 

--- a/test/unit/puppet_class_test.rb
+++ b/test/unit/puppet_class_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/puppet_class'
 
 describe HammerCLIForeman::PuppetClass do
 

--- a/test/unit/report_test.rb
+++ b/test/unit/report_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/report'
 
 describe HammerCLIForeman::Report do
 

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -1,6 +1,8 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/role'
+
 describe HammerCLIForeman::Role do
 
   include CommandTestHelper

--- a/test/unit/smart_class_parameter_test.rb
+++ b/test/unit/smart_class_parameter_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/smart_class_parameter'
 
 describe HammerCLIForeman::SmartClassParameter do
 

--- a/test/unit/smart_proxy_test.rb
+++ b/test/unit/smart_proxy_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/smart_proxy'
 
 describe HammerCLIForeman::SmartProxy do
 

--- a/test/unit/subnet_test.rb
+++ b/test/unit/subnet_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/subnet'
 
 describe HammerCLIForeman::Subnet do
 

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/template'
 
 describe HammerCLIForeman::Template do
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/user'
 
 describe HammerCLIForeman::User do
 

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -1,6 +1,8 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
 
+require 'hammer_cli_foreman/usergroup'
+
 describe HammerCLIForeman::Usergroup do
 
   include CommandTestHelper


### PR DESCRIPTION
Subcommands loaded lazily to speed up hammer's startup.

Requires https://github.com/theforeman/hammer-cli/pull/126
