### PR TITLE
Refs #7083 - adding system locale domain

### DIFF
--- a/lib/hammer_cli_foreman/i18n.rb
+++ b/lib/hammer_cli_foreman/i18n.rb
@@ -18,7 +18,16 @@ module HammerCLIForeman
       end
     end
 
+    class SystemLocaleDomain < LocaleDomain
+
+      def locale_dir
+        '/usr/share/locale'
+      end
+
+    end
+
   end
 end
 
 HammerCLI::I18n.add_domain(HammerCLIForeman::I18n::LocaleDomain.new)
+HammerCLI::I18n.add_domain(HammerCLIForeman::I18n::SystemLocaleDomain.new)


### PR DESCRIPTION
Adding `/usr/share/locale` to the locale search paths.
