### PR TITLE
Fixes #7913 - listing filters for roles always fail with an exception

### DIFF
--- a/lib/hammer_cli_foreman/role.rb
+++ b/lib/hammer_cli_foreman/role.rb
@@ -26,10 +26,7 @@ module HammerCLIForeman
 
       def request_params
         role_id = get_resource_id(HammerCLIForeman.foreman_resource(:roles))
-
-        params = super
-        params[:search] = "role_id = \"#{role_id}\""
-        params
+        { :search => "role_id = \"#{role_id}\"" }
       end
 
       def extend_data(filter)


### PR DESCRIPTION
Listing filters for roles fails with "Missing options to search filter". ListCommand#request_param always tries to resolve name of the command's resource to id. This is not desirable in case of listing roles.
