### PR TITLE
Fixes #9318 - does not resolve a nested host group to id when updating a...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 Gemfile.lock
 Gemfile.local
 pkg
-
+.bundle
+.idea
 # Tests
 test/reports
 coverage

--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -40,7 +40,7 @@ module HammerCLIForeman
       :fact_value =>       [],
       :filter =>           [],
       :host =>             [ s_name(_("Host name")) ],
-      :hostgroup =>        [ s_name(_("Hostgroup name")) ],
+      :hostgroup =>        [ s_name(_("Hostgroup name")),s("title", _("Hostgroup title"),:editable => false) ],
       # :image =>            [],
       :location =>         [ s_name(_("Location name")) ],
       :medium =>           [ s_name(_("Medium name")) ],

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -77,7 +77,7 @@ describe HammerCLIForeman::Hostgroup do
 
     context "parameters" do
       it_should_accept "name, parent_id, environment_id, architecture_id, domain_id, puppet_proxy_id, operatingsystem_id and more",
-          ["--id=1 --name=hostgroup2", "--parent-id=1", "--environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1",
+          ["--id=1 --name=hostgroup2 --title=default/hostgroup2", "--parent-id=1", "--environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1",
             "--operatingsystem-id=1", "--medium-id=1", "--partition-table-id=1", "--subnet-id=1", '--puppet-ca-proxy-id=1', '--puppet-class-ids=1,2']
       # it_should_fail_with "no params", []
       # it_should_fail_with "id missing", ["--name=host2"]


### PR DESCRIPTION
Because nested host groups are not searchable by name (presumable because of the slash in them) we must allow host groups to be searchable via the label attribute.  Without this fix hammer cli foreman does work when trying to either:

a. update a nested host group
b. change the host group of a host to a nested hostgroup

I am not entirely sure why foreman cannot lookup nested hostgroups by name, or if that is a bug in itself.  But this at least allows us to work with nested host groups in the meantime.

Additionally, I added a few more things in the .gitignore file.