### PR TITLE
refs #8980 - update to gettext 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ coverage
 
 # Editors
 tags
+
+# Locale files
+locale/*/*.edit.po
+locale/*/*.po.time_stamp

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,10 @@ source "https://rubygems.org"
 
 gemspec
 
-# for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
-gem 'gettext', '~> 2.0'
+if RUBY_VERSION >= '1.9'
+  # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
+  gem 'gettext', '>= 3.1.3', '< 4.0.0'
+end
 
 group :test do
   gem 'rake', '~> 10.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -11,14 +11,25 @@ end
 
 namespace :gettext do
 
-  desc "Update pot file"
-  task :find do
+  task :setup do
     require "hammer_cli_foreman/version"
     require "hammer_cli_foreman/i18n"
-    require 'gettext/tools'
+    require 'gettext/tools/task'
 
     domain = HammerCLIForeman::I18n::LocaleDomain.new
-    GetText.update_pofiles(domain.domain_name, domain.translated_files, "#{domain.domain_name} #{HammerCLIForeman.version.to_s}", :po_root => domain.locale_dir)
+    GetText::Tools::Task.define do |task|
+      task.package_name = domain.domain_name
+      task.package_version = HammerCLIForeman.version.to_s
+      task.domain = domain.domain_name
+      task.mo_base_directory = domain.locale_dir
+      task.po_base_directory = domain.locale_dir
+      task.files = domain.translated_files
+    end
+  end
+
+  desc "Update pot file"
+  task :find => [:setup] do
+    Rake::Task["gettext:po:update"].invoke
   end
 
 end

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -10,9 +10,10 @@ DOMAIN = hammer-cli-foreman
 VERSION = $(shell ruby -e 'require "rubygems";spec = Gem::Specification::load("../hammer_cli_foreman.gemspec");puts spec.version')
 POTFILE = $(DOMAIN).pot
 MOFILE = $(DOMAIN).mo
-POFILES = $(shell find . -name '*.po')
+POFILES = $(shell find . -name '$(DOMAIN).po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
 POXFILES = $(patsubst %.po,%.pox,$(POFILES))
+EDITFILES = $(patsubst %.po,%.edit.po,$(POFILES))
 
 %.mo: %.po
 	mkdir -p $(shell dirname $@)/LC_MESSAGES
@@ -30,13 +31,6 @@ all-mo: $(MOFILES)
 	! grep -q msgid $@
 
 check: $(POXFILES)
-	msgfmt -c ${POTFILE}
-
-# Merge PO files
-update-po:
-	for f in $(shell find ./ -name "*.po") ; do \
-		msgmerge -N --backup=none -U $$f ${POTFILE} ; \
-	done
 
 # Unify duplicate translations
 uniq-po:
@@ -44,22 +38,20 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
-tx-pull:
+tx-pull: $(EDITFILES)
 	tx pull -f
 	for f in $(POFILES) ; do \
 		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
 	done
-	-git commit -a -m "i18n - extracting new, pulling from tx"
 
+# Extract strings and update the .pot, prepare .edit.po files
 extract-strings:
 	bundle exec rake gettext:find
 
-reset-po:
-	# merging po files is unnecessary when using transifex.com
-	git checkout -- ../locale/*/*po
+# Merge .edit.po into .po
+update-po:
+	bundle exec rake gettext:find
 
-tx-update: tx-pull extract-strings reset-po $(MOFILES)
-	# amend mo files
-	git add ../locale/*/LC_MESSAGES
-	git commit -a --amend -m "i18n - extracting new, pulling from tx"
+tx-update: extract-strings tx-pull $(MOFILES)
+	git commit -m "i18n - extracting new, pulling from tx" ../locale
 	-echo Changes commited!


### PR DESCRIPTION
3.1.13 adds an intermediate .edit.po file alongside each .po, which is meant
to be kept outside of SCM and updated by users, whereupon it's merged back into
the .po on the next rake gettext:find execution.

Previously we overwrote all gettext .po file changes with files directly from
Transifex, but now these are downloaded to .edit.po and gettext merges them
back in.

Continuation of https://github.com/theforeman/hammer-cli/pull/160