### PR TITLE
refs #9648 - use correct domain for system locales, only load one domain

### DIFF
--- a/lib/hammer_cli_foreman/i18n.rb
+++ b/lib/hammer_cli_foreman/i18n.rb
@@ -24,14 +24,10 @@ module HammerCLIForeman
         '/usr/share/locale'
       end
 
-      def domain_name
-        "#{super}@system"
-      end
-
     end
 
   end
 end
 
-HammerCLI::I18n.add_domain(HammerCLIForeman::I18n::LocaleDomain.new)
-HammerCLI::I18n.add_domain(HammerCLIForeman::I18n::SystemLocaleDomain.new)
+domain = [HammerCLIForeman::I18n::LocaleDomain.new, HammerCLIForeman::I18n::SystemLocaleDomain.new].find { |d| d.available? }
+HammerCLI::I18n.add_domain(domain) if domain


### PR DESCRIPTION
This reverts commit 96ee3d8cb0f0da278bac50ceb4cc15e9092e382f.

Depends on https://github.com/theforeman/hammer-cli/pull/166