### PR TITLE
host_create docs usage is out of date with 0.2.0 release

### DIFF
--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -15,15 +15,12 @@ Options:
  --ask-root-password ASK_ROOT_PW           One of true/false, yes/no, 1/0.
  --build BUILD                             One of true/false, yes/no, 1/0.
                                            Default: "true"
- --comment COMMENT                         Additional information about this host
  --compute-attributes COMPUTE_ATTRS        Compute resource attributes.
                                            Comma-separated list of key=value.
- --compute-profile COMPUTE_PROFILE_NAME    Name to search by
- --compute-profile-id COMPUTE_PROFILE_ID
  --compute-resource COMPUTE_RESOURCE_NAME  Compute resource name
  --compute-resource-id COMPUTE_RESOURCE_ID
  --domain DOMAIN_NAME                      Domain name
- --domain-id DOMAIN_ID                     Numerical ID or domain name
+ --domain-id DOMAIN_ID                     May be numerical id or domain name
  --enabled ENABLED                         One of true/false, yes/no, 1/0.
                                            Default: "true"
  --environment ENVIRONMENT_NAME            Environment name
@@ -36,10 +33,8 @@ Options:
  --interface INTERFACE                     Interface parameters.
                                            Comma-separated list of key=value.
                                            Can be specified multiple times.
- --ip IP                                   not required if using a subnet with DHCP proxy
- --location LOCATION_NAME                  Location name
- --location-id LOCATION_ID
- --mac MAC                                 required for managed host that is bare metal, not required if it’s a virtual machine
+ --ip IP                                   not required if using a subnet with dhcp proxy
+ --mac MAC                                 not required if its a virtual machine
  --managed MANAGED                         One of true/false, yes/no, 1/0.
                                            Default: "true"
  --medium MEDIUM_NAME                      Medium name
@@ -49,16 +44,14 @@ Options:
  --name NAME
  --operatingsystem OPERATINGSYSTEM_TITLE   Operating system title
  --operatingsystem-id OPERATINGSYSTEM_ID
- --organization ORGANIZATION_NAME          Organization name
- --organization-id ORGANIZATION_ID
  --owner OWNER_LOGIN                       Login of the owner
  --owner-id OWNER_ID                       ID of the owner
- --owner-type OWNER_TYPE                   Host’s owner type
  --parameters PARAMS                       Host parameters.
                                            Comma-separated list of key=value.
  --partition-table PARTITION_TABLE_NAME    Partition table name
  --partition-table-id PARTITION_TABLE_ID
- --progress-report-id PROGRESS_REPORT_ID   UUID to track orchestration tasks status, GET /api/orchestration/:UUID/tasks
+ --progress-report-id PROGRESS_REPORT_ID   UUID to track orchestration tasks status, GET
+                                           /api/orchestration/:UUID/tasks
  --provision-method METHOD                 One of 'build', 'image'
  --puppet-ca-proxy PUPPET_CA_PROXY_NAME
  --puppet-ca-proxy-id PUPPET_CA_PROXY_ID
@@ -67,9 +60,9 @@ Options:
  --puppet-proxy PUPPET_PROXY_NAME
  --puppet-proxy-id PUPPET_PROXY_ID
  --realm REALM_NAME                        Name to search by
- --realm-id REALM_ID                       Numerical ID or realm name
- --root-pass ROOT_PASS                     required if host is managed and value is not inherited from host group or default password in settings
+ --realm-id REALM_ID                       May be numerical id or realm name
  --root-password ROOT_PW
+ --sp-subnet-id SP_SUBNET_ID
  --subnet SUBNET_NAME                      Subnet name
  --subnet-id SUBNET_ID
  --volume VOLUME                           Volume parameters


### PR DESCRIPTION
I'm a little confused as to why these options are in the docs but not the actual code.  A lot of them seem very important to set.  Maybe a better fix is to implement the missing options?  But it is very misleading to document something that does not exist...