### PR TITLE
Fixes #3968 - adding a command for building PXE default

### DIFF
--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -18,8 +18,8 @@ module HammerCLIForeman
 
     def handle_unprocessable_entity(e)
       response = JSON.parse(e.response)
-      response = HammerCLIForeman.record_to_common_format(response)
-      print_error response['full_messages']
+      response = HammerCLIForeman.record_to_common_format(response) unless response.has_key?('message')
+      print_error response['message'] || response['full_messages']
       HammerCLI::EX_DATAERR
     end
 
@@ -60,7 +60,7 @@ module HammerCLIForeman
     def handle_foreman_error(e)
       begin
         response = JSON.parse(e.response)
-        response = HammerCLIForeman.record_to_common_format(response)
+        response = HammerCLIForeman.record_to_common_format(response) unless response.has_key?('message')
         message = response['message'] || e.message
       rescue JSON::ParserError => parse_e
         message = e.message

--- a/lib/hammer_cli_foreman/template.rb
+++ b/lib/hammer_cli_foreman/template.rb
@@ -142,6 +142,21 @@ module HammerCLIForeman
     end
 
 
+    class BuildPXEDefaultCommand < HammerCLIForeman::Command
+
+      action :build_pxe_default
+
+      command_name "build-pxe-default"
+      desc _("Update the default PXE menu on all configured TFTP servers")
+
+      def print_data(message)
+        puts message
+      end
+
+      build_options
+    end
+
+
     HammerCLIForeman::AssociatingCommands::OperatingSystem.extend_command(self)
 
 

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -98,7 +98,19 @@ describe HammerCLIForeman::ExceptionHandler do
     ex = RestClient::InternalServerError.new(response)
     ex.stubs(:message).returns(response)
 
-    output.expects(:print_error).with("Something went wrong", "Unformatted\nlines\n")
+    output.expects(:print_error).with(heading, "Unformatted\nlines\n")
+    err_code = handler.handle_exception(ex, :heading => heading)
+    err_code.must_equal HammerCLI::EX_SOFTWARE
+  end
+
+  it "should print exception message on internal error exception with message that is not nested" do
+    response = <<-RESPONSE
+    {"message":"Some internal exception"}
+    RESPONSE
+    ex = RestClient::InternalServerError.new(response)
+    ex.stubs(:message).returns(response)
+
+    output.expects(:print_error).with(heading, "Some internal exception")
     err_code = handler.handle_exception(ex, :heading => heading)
     err_code.must_equal HammerCLI::EX_SOFTWARE
   end


### PR DESCRIPTION
- adds `template build-pxe-default`
- extends exception handling to accept messages being stored in the first level of the response hash