### PR TITLE
Fixes #8015 - Ability to use user's default Org/Location in hammer CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ Gemfile.lock
 Gemfile.local
 pkg
 .bundle
-
+.rvmrc
 # RubyMine
 .idea
 
@@ -21,3 +21,5 @@ tags
 # Locale files
 locale/*/*.edit.po
 locale/*/*.po.time_stamp
+config/cli_config.yml
+config/cli.modules.d/

--- a/config/foreman.yml
+++ b/config/foreman.yml
@@ -14,3 +14,9 @@
 
   # API request timeout. Set to -1 for no timeout
   #:request_timeout: 120 #seconds
+
+  # Set default values for those options
+  #:organization_id: -1
+  #:organization_name: -1
+  #:location_id: -1
+  #:location_name: -1

--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -1,5 +1,6 @@
 module HammerCLIForeman
 
+  DEFAULT_OPTIONS_FOR_COMMANDS = ['organization_id', 'location_id', 'organization_name', 'location_name']
   CONNECTION_NAME = 'foreman'
 
   RESOURCE_NAME_MAPPING = {
@@ -181,7 +182,20 @@ module HammerCLIForeman
       @searchables
     end
 
+    def check_for_default_options()
+      DEFAULT_OPTIONS_FOR_COMMANDS.each do |option|
+      if use_default?(option)
+        self.instance_variable_set("@option_#{option}", HammerCLI::Settings.get(:foreman, option.to_sym))
+      end
+      end
+    end
+
+    def use_default?(option)
+      self.instance_variable_defined?("@option_#{option}") && self.instance_variable_get("@option_#{option}").nil? && HammerCLI::Settings.get(:foreman, option.to_sym)
+    end
+
     def send_request
+      check_for_default_options()
       transform_format(super)
     rescue HammerCLIForeman::MissingSeachOptions => e
 


### PR DESCRIPTION
I have added the ability to set default values for location/organization options for the API commands.
The way you set them is by using Foreman.yml.