### PR TITLE
Fixes #11137 - Add normalizer converting id parameter values to numbers

### DIFF
--- a/lib/hammer_cli_foreman/option_builders.rb
+++ b/lib/hammer_cli_foreman/option_builders.rb
@@ -243,6 +243,7 @@ module HammerCLIForeman
         "#{aliased_name}_id".upcase,
         description("id", :show),
         :attribute_name => HammerCLI.option_accessor_name("#{resource_name}_id"),
+        :format => HammerCLI::Options::Normalizers::Number.new,
         :referenced_resource => resource.singular_name
       )
       options

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -98,7 +98,7 @@ describe HammerCLIForeman::Domain do
 
     context "parameters" do
       it_should_accept "name, value and domain name", ["--name=name", "--value=val", "--domain=name"]
-      it_should_accept "name, value and domain id", ["--name=name", "--value=val", "--domain-id=id"]
+      it_should_accept "name, value and domain id", ["--name=name", "--value=val", "--domain-id=1"]
       # it_should_fail_with "name missing", ["--value=val", "--domain=name"]
       # it_should_fail_with "value missing", ["--name=name", "--domain=name"]
       # it_should_fail_with "domain name or id missing", ["--name=name", "--value=val"]
@@ -114,7 +114,7 @@ describe HammerCLIForeman::Domain do
 
     context "parameters" do
       it_should_accept "name and domain name", ["--name=param", "--domain=name"]
-      it_should_accept "name and domain id", ["--name=param", "--domain-id=id"]
+      it_should_accept "name and domain id", ["--name=param", "--domain-id=1"]
 
       # it_should_fail_with "name missing", ["--domain=name"]
       # it_should_fail_with "domain name or id missing", ["--name=param"]

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -217,7 +217,7 @@ describe HammerCLIForeman::Host do
       it_should_fail_with "operatingsystem_id missing",
           ["--name=host", "--environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1", "--interface=primary=true,provision=true"]
       it_should_accept "only hostgroup name", ["--hostgroup=example", "--name=host", "--interface=primary=true,provision=true"]
-      it_should_accept "only hostgroup ID", ["--hostgroup-id=example", "--name=host", "--interface=primary=true,provision=true"]
+      it_should_accept "only hostgroup ID", ["--hostgroup-id=1", "--name=host", "--interface=primary=true,provision=true"]
 
       with_params ["--name=host", "--environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1", "--operatingsystem-id=1",
             "--ip=1.2.3.4", "--mac=11:22:33:44:55:66", "--medium-id=1", "--partition-table-id=1", "--subnet-id=1",
@@ -299,7 +299,7 @@ describe HammerCLIForeman::Host do
 
     context "parameters" do
       it_should_accept "name, value and host name", ["--name=name", "--value=val", "--host=name"]
-      it_should_accept "name, value and host id", ["--name=name", "--value=val", "--host-id=id"]
+      it_should_accept "name, value and host id", ["--name=name", "--value=val", "--host-id=1"]
       it_should_fail_with "name missing", ["--value=val", "--host=name"]
       it_should_fail_with "value missing", ["--name=name", "--host=name"]
       # it_should_fail_with "host name or id missing", ["--name=name", "--value=val"]
@@ -315,7 +315,7 @@ describe HammerCLIForeman::Host do
 
     context "parameters" do
       it_should_accept "name and host name", ["--name=name", "--host=name"]
-      it_should_accept "name and host id", ["--name=name", "--host-id=id"]
+      it_should_accept "name and host id", ["--name=name", "--host-id=1"]
       # it_should_fail_with "name missing", ["--host=name"]
       # it_should_fail_with "host name or id missing", ["--name=name"]
       # TODO: temporarily disabled, parameters are checked in the id resolver
@@ -387,5 +387,3 @@ describe HammerCLIForeman::Host do
   end
 
 end
-
-

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -96,7 +96,7 @@ describe HammerCLIForeman::Hostgroup do
     let(:cmd) { HammerCLIForeman::Hostgroup::SetParameterCommand.new("", ctx) }
 
     context "parameters" do
-      it_should_accept "name, value and hostgroup id", ["--name=name", "--value=val", "--hostgroup-id=id"]
+      it_should_accept "name, value and hostgroup id", ["--name=name", "--value=val", "--hostgroup-id=1"]
       it_should_fail_with "name missing", ["--value=val", "--hostgroup-id=1"]
       it_should_fail_with "value missing", ["--name=name", "--hostgroup-id=1"]
       # it_should_fail_with "hostgroup id missing", ["--name=name", "--value=val"] # TODO: temporarily disabled, parameters are checked in the id resolver
@@ -110,7 +110,7 @@ describe HammerCLIForeman::Hostgroup do
     let(:cmd) { HammerCLIForeman::Hostgroup::DeleteParameterCommand.new("", ctx) }
 
     context "parameters" do
-      it_should_accept "name and hostgroup id", ["--name=param", "--hostgroup-id=id"]
+      it_should_accept "name and hostgroup id", ["--name=param", "--hostgroup-id=1"]
       # it_should_fail_with "name missing", ["--hostgroup-id=id"]
       # it_should_fail_with "hostgroup id missing", ["--name=param"]
       # TODO: temporarily disabled, parameters are checked in the id resolver
@@ -152,4 +152,3 @@ describe HammerCLIForeman::Hostgroup do
   end
 
 end
-

--- a/test/unit/operating_system_test.rb
+++ b/test/unit/operating_system_test.rb
@@ -124,7 +124,7 @@ describe HammerCLIForeman::OperatingSystem do
     let(:cmd) { HammerCLIForeman::OperatingSystem::SetParameterCommand.new("", ctx) }
 
     context "parameters" do
-      it_should_accept "name, value and os id", ["--name=domain", "--value=val", "--operatingsystem-id=id"]
+      it_should_accept "name, value and os id", ["--name=domain", "--value=val", "--operatingsystem-id=1"]
       it_should_accept "name, value and os title", ["--name=domain", "--value=val", "--operatingsystem=Rhel 6.5"]
       # it_should_fail_with "name missing", ["--value=val", "--operatingsystem-id=id"]
       # it_should_fail_with "value missing", ["--name=name", "--operatingsystem-id=id"]
@@ -140,7 +140,7 @@ describe HammerCLIForeman::OperatingSystem do
     let(:cmd) { HammerCLIForeman::OperatingSystem::DeleteParameterCommand.new("", ctx) }
 
     context "parameters" do
-      it_should_accept "name and os id", ["--name=domain", "--operatingsystem-id=id"]
+      it_should_accept "name and os id", ["--name=domain", "--operatingsystem-id=1"]
       it_should_accept "name and os title", ["--name=domain", "--operatingsystem=Rhel 6.5"]
       # it_should_fail_with "name missing", ["--operatingsystem-id=id"]
       # it_should_fail_with "os id missing", ["--name=name"]


### PR DESCRIPTION
Send id parameters in appropriate numeric format
Requires theforeman/hammer-cli#173 to be merged
Tests were updated 
