### PR TITLE
Fixes #11088 - Missing field for VMWare host creation docs

### DIFF
--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -232,6 +232,16 @@ path
 
 Available keys for `--interface`:
 ```
+compute_type      # Type of the network adapter, for example one of:
+                  #   VirtualVmxnet
+                  #   VirtualVmxnet2
+                  #   VirtualVmxnet3
+                  #   VirtualE1000
+                  #   VirtualE1000e
+                  #   VirtualPCNet32
+                  # See documentation center for your version of vSphere to find
+                  # more details about available adapter types:
+                  # https://www.vmware.com/support/pubs/
 compute_network
 ```
 


### PR DESCRIPTION
Example inputs are based on:
https://www.vmware.com/support/developer/converter-sdk/conv55_apireference/vim.vm.device.VirtualEthernetCard.html