### PR TITLE
Fixes #12090 - Allows 0.4 to work with foreman 1.10-dev

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -112,7 +112,7 @@ module HammerCLIForeman
     def parameter_attributes
       return {} unless option_parameters
       option_parameters.collect do |key, value|
-        {"name"=>key, "value"=>value.inspect, "nested"=>""}
+        {"name"=>key, "value"=>value.inspect}
       end
     end
 


### PR DESCRIPTION
This fixes the problem for me and allows me to use foreman-cli with the nightly.