### PR TITLE
Fixes #12112 - Removing credentials in case login was unsuccessful in interactive mode

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -202,6 +202,9 @@ module HammerCLIForeman
         },
         e.resource
       )
+    rescue Exception => e
+      HammerCLIForeman.foreman_api_connection.api.clear_credentials if e.to_s.include?"401"
+      raise e
     end
 
     def transform_format(data)


### PR DESCRIPTION
A change to apipie-bindings was also made to support this patch and must be merged before this one works.(https://github.com/Apipie/apipie-bindings/pull/31)