### PR TITLE
Fixes #12202 - string parameters get double-quoted

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -112,7 +112,11 @@ module HammerCLIForeman
     def parameter_attributes
       return {} unless option_parameters
       option_parameters.collect do |key, value|
-        {"name"=>key, "value"=>value.inspect}
+        if value.is_a? String
+          {"name"=>key, "value"=>value}
+        else
+          {"name"=>key, "value"=>value.inspect}
+        end
       end
     end
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -231,8 +231,11 @@ describe HammerCLIForeman::Host do
         it_should_call_action_and_test_params(:create) { |par| par["host"]["interfaces_attributes"]["0"]["provision"] == "true" }
       end
 
-      with_params ["--name=host", "--hostgroup-id=1", "--interface=primary=true,provision=true", "--parameters=servers=[pool.ntp.org,ntp.time.org]"] do
-        it_should_call_action_and_test_params(:create) { |par| par["host"]["host_parameters_attributes"][0]["value"] == "[\"pool.ntp.org\", \"ntp.time.org\"]" }
+      with_params ["--name=host", "--hostgroup-id=1", "--interface=primary=true,provision=true", "--parameters=servers=[pool.ntp.org,ntp.time.org],password=secret"] do
+        it_should_call_action_and_test_params(:create) do |par|
+          par["host"]["host_parameters_attributes"][0]["value"] == "[\"pool.ntp.org\", \"ntp.time.org\"]" &&
+          par["host"]["host_parameters_attributes"][1]["value"] == "secret"
+        end
       end
 
       it_should_fail_with "primary interface missing", ["--hostgroup-id=example", "--interface=primary=true"]


### PR DESCRIPTION
With this patch
```
hammer host update --id 1 --parameters 'password=secret'
```
no longer creates parameter `password` with double quoted value `'"secret"'`. The value is created without the quotes now.