### PR TITLE
Fixes #9208 - add option to overwrite conflicts on host changes

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -38,6 +38,8 @@ module HammerCLIForeman
       base.option "--build", "BUILD", " ", bme_options
       bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
       base.option "--enabled", "ENABLED", " ",  bme_options
+      bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
+      base.option "--overwrite", "OVERWRITE", " ",  bme_options
 
       base.option "--parameters", "PARAMS", _("Host parameters."),
         :format => HammerCLI::Options::Normalizers::KeyValueList.new
@@ -81,6 +83,7 @@ module HammerCLIForeman
       params['host']['build'] = option_build unless option_build.nil?
       params['host']['managed'] = option_managed unless option_managed.nil?
       params['host']['enabled'] = option_enabled unless option_enabled.nil?
+      params['host']['overwrite'] = option_overwrite unless option_overwrite.nil?
 
       params['host']['host_parameters_attributes'] = parameter_attributes
       params['host']['compute_attributes'] = option_compute_attributes || {}

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -266,6 +266,7 @@ describe HammerCLIForeman::Host do
         it_should_call_action_and_test_params(:update) { |par| par["host"].key?("managed") != true }
         it_should_call_action_and_test_params(:update) { |par| par["host"].key?("build") != true }
         it_should_call_action_and_test_params(:update) { |par| par["host"].key?("enabled") != true }
+        it_should_call_action_and_test_params(:update) { |par| par["host"].key?("overwrite") != true }
       end
 
       with_params ["--id=1", "--enabled=true"] do
@@ -274,6 +275,10 @@ describe HammerCLIForeman::Host do
 
       with_params ["--id=1", "--enabled=false"] do
         it_should_call_action_and_test_params(:update) { |par| par["host"]["enabled"] == false }
+      end
+
+      with_params ["--id=1", "--overwrite=true"] do
+        it_should_call_action_and_test_params(:update) { |par| par["host"]["overwrite"] == true }
       end
 
       with_params ["--id=1","--provision-method=build"] do


### PR DESCRIPTION
Add an hammer option to the host subcommand to allow overwriting of DHCP/DNS entries when updating or creating a host.

Issue - http://projects.theforeman.org/issues/9208