### PR TITLE
Fixes #12699 - Commands for setting parameters at taxonomies

### DIFF
--- a/lib/hammer_cli_foreman/location.rb
+++ b/lib/hammer_cli_foreman/location.rb
@@ -81,6 +81,27 @@ module HammerCLIForeman
       end
     end
 
+
+    class SetParameterCommand < HammerCLIForeman::Parameter::SetCommand
+      desc _("Create or update parameter for a location.")
+
+      success_message_for :update, _("Parameter [%{name}] updated to value [%{value}]")
+      success_message_for :create, _("Parameter [%{name}] created with value [%{value}]")
+      failure_message _("Could not set location parameter")
+
+      build_options
+    end
+
+
+    class DeleteParameterCommand < HammerCLIForeman::Parameter::DeleteCommand
+      desc _("Delete parameter for a location.")
+
+      success_message _("Parameter [%{name}] deleted")
+      failure_message _("Could not delete location parameter")
+
+      build_options
+    end
+
     HammerCLIForeman::AssociatingCommands::Hostgroup.extend_command(self)
     HammerCLIForeman::AssociatingCommands::Environment.extend_command(self)
     HammerCLIForeman::AssociatingCommands::Domain.extend_command(self)

--- a/lib/hammer_cli_foreman/organization.rb
+++ b/lib/hammer_cli_foreman/organization.rb
@@ -83,6 +83,27 @@ module HammerCLIForeman
     end
 
 
+    class SetParameterCommand < HammerCLIForeman::Parameter::SetCommand
+      desc _("Create or update parameter for an organization.")
+
+      success_message_for :update, _("Parameter [%{name}] updated to value [%{value}]")
+      success_message_for :create, _("Parameter [%{name}] created with value [%{value}]")
+      failure_message _("Could not set organization parameter")
+
+      build_options
+    end
+
+
+    class DeleteParameterCommand < HammerCLIForeman::Parameter::DeleteCommand
+      desc _("Delete parameter for an organization.")
+
+      success_message _("Parameter [%{name}] deleted")
+      failure_message _("Could not delete organization parameter")
+
+      build_options
+    end
+
+
     HammerCLIForeman::AssociatingCommands::Hostgroup.extend_command(self)
     HammerCLIForeman::AssociatingCommands::Environment.extend_command(self)
     HammerCLIForeman::AssociatingCommands::Domain.extend_command(self)

--- a/lib/hammer_cli_foreman/parameter.rb
+++ b/lib/hammer_cli_foreman/parameter.rb
@@ -55,11 +55,11 @@ module HammerCLIForeman
 
       def execute
         if parameter_exist?
-          update_parameter
-          print_message success_message_for :update if success_message_for :update
+          response = update_parameter
+          print_message(success_message_for(:update), response) if success_message_for(:update)
         else
-          create_parameter
-          print_message success_message_for :create if success_message_for :create
+          response = create_parameter
+          print_message(success_message_for(:create), response) if success_message_for(:create)
         end
         HammerCLI::EX_OK
       end
@@ -102,10 +102,10 @@ module HammerCLIForeman
       def execute
         params = {
           "id" => get_parameter_identifier
-        }.merge base_action_params
+        }.merge(base_action_params)
 
-        HammerCLIForeman.record_to_common_format(parameter_resource.call(:destroy, params))
-        print_message success_message if success_message
+        response = HammerCLIForeman.record_to_common_format(parameter_resource.call(:destroy, params))
+        print_message(success_message, response) if success_message
         HammerCLI::EX_OK
       end
 

--- a/test/functional/api_expectations.rb
+++ b/test/functional/api_expectations.rb
@@ -11,9 +11,9 @@ module APIExpectations
       resource, action, params, headers, options = actual_parameters.shift(5)
 
       result = true
-      result = result && (resource.to_s == @expected_resource.to_s) unless @expected_resource.nil?
-      result = result && (action.to_s == @expected_action.to_s) unless @expected_action.nil?
-      result = result && @block.call(params) if @block
+      result &&= (resource.to_s == @expected_resource.to_s) unless @expected_resource.nil?
+      result &&= (action.to_s == @expected_action.to_s) unless @expected_action.nil?
+      result &&= @block.call(params) if @block
       result
     end
 

--- a/test/functional/api_expectations.rb
+++ b/test/functional/api_expectations.rb
@@ -1,0 +1,65 @@
+module APIExpectations
+
+  class BlockMatcher < Mocha::ParameterMatchers::Base
+    def initialize(resource=nil, action=nil, &block)
+      @expected_resource = resource
+      @expected_action = action
+      @block = block if block_given?
+    end
+
+    def matches?(actual_parameters)
+      resource, action, params, headers, options = actual_parameters.shift(5)
+
+      result = true
+      result = result && (resource.to_s == @expected_resource.to_s) unless @expected_resource.nil?
+      result = result && (action.to_s == @expected_action.to_s) unless @expected_action.nil?
+      result = result && @block.call(params) if @block
+      result
+    end
+
+    def mocha_inspect
+      res = @expected_resource.nil? ? 'any_resource' : ":#{@expected_resource}"
+      act = @expected_action.nil? ? 'any_action' : ":#{@expected_action}"
+      blk = @block ? '&block' : '*any_argument'
+      "#{res}, #{act}, #{blk}"
+    end
+  end
+
+  module ExpectationExtensions
+    def method_signature
+      "#{@note}\n  #{super}"
+    end
+
+    def set_note(note)
+      @note = note
+    end
+  end
+
+  def api_expects(resource=nil, action=nil, note=nil, &block)
+    ex = ApipieBindings::API.any_instance.expects(:call)
+    ex.extend(ExpectationExtensions)
+    ex.with(BlockMatcher.new(resource, action, &block))
+    ex.set_note(note)
+    ex
+  end
+
+  def api_expects_no_call
+    ApipieBindings::API.any_instance.expects(:call).never
+  end
+
+  def index_response(items)
+    cnt = items.length
+    {
+      "total" => cnt,
+      "subtotal" => cnt,
+      "page" => 1,
+      "per_page" => cnt,
+      "search" => "",
+      "sort" => {
+        "by" => nil,
+        "order" => nil
+      },
+      "results" => items
+    }
+  end
+end

--- a/test/functional/command_assertions.rb
+++ b/test/functional/command_assertions.rb
@@ -1,0 +1,76 @@
+module CommandAssertions
+
+  class CommandRunResult
+    def initialize(out="", err="", exit_code=0)
+      @out = out
+      @err = err
+      @exit_code = exit_code
+    end
+    attr_accessor :out, :err, :exit_code
+  end
+
+  def run_cmd(options, context={}, cmd_class=HammerCLI::MainCommand)
+    result = CommandRunResult.new
+    result.out, result.err = capture_io do
+      result.exit_code = cmd_class.run('hammer', options, context)
+    end
+    result
+  end
+
+  def exit_code_map
+    return @exit_code_map unless @exit_code_map.nil?
+
+    hammer_exit_codes = HammerCLI.constants.select{|c| c.to_s.start_with?('EX_')}
+    @exit_code_map = hammer_exit_codes.inject({}) do |code_map, code|
+      code_map.update(HammerCLI.const_get(code) => code)
+    end
+  end
+
+  def assert_exit_code_equal(expected_code, actual_code)
+    expected_info = "#{exit_code_map[expected_code]} (#{expected_code})"
+    actual_info = "#{exit_code_map[actual_code]} (#{actual_code})"
+
+    msg = "The exit code was expected to be #{expected_info}, but it was #{actual_info}"
+    assert(expected_code == actual_code, msg)
+  end
+
+  def assert_cmd(expected_result, actual_result)
+    assert_equal expected_result.err, actual_result.err
+    assert_equal expected_result.out, actual_result.out
+    assert_exit_code_equal expected_result.exit_code, actual_result.exit_code
+  end
+
+  def usage_error(command, heading, message)
+    command = (['hammer'] + command).join(' ')
+    ["#{heading}:",
+     "  Error: #{message}",
+     "  ",
+     "  See: '#{command} --help'",
+     ""].join("\n")
+  end
+
+  def common_error(command, heading, message)
+    command = (['hammer'] + command).join(' ')
+    ["#{heading}:",
+     "  Error: #{message}",
+     ""].join("\n")
+  end
+
+  def usage_error_result(command, heading, message)
+    expected_result = CommandRunResult.new
+    expected_result.err = usage_error(command, heading, message)
+    expected_result.exit_code = HammerCLI::EX_USAGE
+    expected_result
+  end
+
+  def common_error_result(command, heading, message)
+    expected_result = CommandRunResult.new
+    expected_result.err = common_error(command, heading, message)
+    expected_result.exit_code = HammerCLI::EX_SOFTWARE
+    expected_result
+  end
+
+  def success_result(message)
+    CommandRunResult.new(message)
+  end
+end

--- a/test/functional/location_test.rb
+++ b/test/functional/location_test.rb
@@ -1,0 +1,136 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+
+describe "parameters" do
+
+  let(:param) do
+    {
+      "priority" => nil,
+      "created_at" => "2015-12-03T01:57:55Z",
+      "updated_at" => "2015-12-03T01:57:55Z",
+      "id" => 15,
+      "name" => "B",
+      "value" => "2"
+    }
+  end
+
+  describe "set" do
+
+    before do
+      @cmd = ["location", "set-parameter"]
+      @params = []
+    end
+
+    it "should print error on missing --name" do
+      @params = ['--value=1']
+      expected_result = usage_error_result(
+        @cmd,
+        "Could not set location parameter",
+        "option '--name' is required"
+      )
+
+      api_expects_no_call
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+    it "should print error on missing --value" do
+      @params = ['--name=A']
+      expected_result = usage_error_result(
+        @cmd,
+        "Could not set location parameter",
+        "option '--value' is required"
+      )
+
+      api_expects_no_call
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+
+    it "should create new parameter" do
+
+      api_expects(:parameters, :index, 'Attempt find parameters') do |par|
+        par['location_id'].to_i == 3
+      end.returns(index_response([]))
+      api_expects(:parameters, :create, 'Create parameter') do |par|
+        par['parameter']['name'] == 'A' &&
+        par['parameter']['value'] == '1'
+      end.returns({:name => 'A', :value => '1'})
+
+      @params = ['--name=A', '--value=1', '--location-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(success_result("Parameter [A] created with value [1]\n"), result)
+    end
+
+
+    it "should update existing parameter" do
+      api_expects(:parameters, :index, 'Find parameter') do |par|
+        par['location_id'].to_i == 3
+      end.returns(index_response([param]))
+      api_expects(:parameters, :update, 'Update parameter') do |par|
+        par['id'].to_i == 15 &&
+        par['location_id'].to_i == 3 &&
+        par['parameter']['value'] == '1'
+      end.returns({:name => 'A', :value => '1'})
+
+
+      @params = ['--name=A', '--value=1', '--location-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(success_result("Parameter [A] updated to value [1]\n"), result)
+    end
+  end
+
+
+  describe "delete" do
+    before do
+      @cmd = ["location", "delete-parameter"]
+      @params = []
+    end
+
+    it "should print error on missing --name" do
+      expected_result = usage_error_result(
+        @cmd,
+        "Could not delete location parameter",
+        "option '--name' is required"
+      )
+
+      api_expects_no_call
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+    it "should print error when the parameter doesn't exist" do
+      api_expects(:parameters, :index, 'Find parameter') do |par|
+        par['location_id'].to_i == 3
+      end.returns(index_response([]))
+
+      expected_result = common_error_result(
+        @cmd,
+        "Could not delete location parameter",
+        "parameter not found"
+      )
+
+      @params = ['--name=A', '--location-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+    it "should delete the parameter" do
+      api_expects(:parameters, :index, 'Find parameter') do |par|
+        par['location_id'].to_i == 3
+      end.returns(index_response([param]))
+      api_expects(:parameters, :destroy, 'Delete parameter') do |par|
+        par['id'] == param['id']
+      end.returns({:name => 'A', :value => '1'})
+
+      expected_result = success_result(
+        "Parameter [A] deleted\n"
+      )
+
+      @params = ['--name=A', '--location-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+  end
+end

--- a/test/functional/location_test.rb
+++ b/test/functional/location_test.rb
@@ -18,11 +18,11 @@ describe "parameters" do
 
     before do
       @cmd = ["location", "set-parameter"]
-      @params = []
     end
 
     it "should print error on missing --name" do
-      @params = ['--value=1']
+      params = ['--value=1']
+
       expected_result = usage_error_result(
         @cmd,
         "Could not set location parameter",
@@ -30,12 +30,13 @@ describe "parameters" do
       )
 
       api_expects_no_call
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
     it "should print error on missing --value" do
-      @params = ['--name=A']
+      params = ['--name=A']
+
       expected_result = usage_error_result(
         @cmd,
         "Could not set location parameter",
@@ -43,12 +44,13 @@ describe "parameters" do
       )
 
       api_expects_no_call
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
 
     it "should create new parameter" do
+      params = ['--name=A', '--value=1', '--location-id=3']
 
       api_expects(:parameters, :index, 'Attempt find parameters') do |par|
         par['location_id'].to_i == 3
@@ -58,13 +60,14 @@ describe "parameters" do
         par['parameter']['value'] == '1'
       end.returns({:name => 'A', :value => '1'})
 
-      @params = ['--name=A', '--value=1', '--location-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(success_result("Parameter [A] created with value [1]\n"), result)
     end
 
 
     it "should update existing parameter" do
+      params = ['--name=A', '--value=1', '--location-id=3']
+
       api_expects(:parameters, :index, 'Find parameter') do |par|
         par['location_id'].to_i == 3
       end.returns(index_response([param]))
@@ -74,9 +77,7 @@ describe "parameters" do
         par['parameter']['value'] == '1'
       end.returns({:name => 'A', :value => '1'})
 
-
-      @params = ['--name=A', '--value=1', '--location-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(success_result("Parameter [A] updated to value [1]\n"), result)
     end
   end
@@ -85,10 +86,11 @@ describe "parameters" do
   describe "delete" do
     before do
       @cmd = ["location", "delete-parameter"]
-      @params = []
     end
 
     it "should print error on missing --name" do
+      params = []
+
       expected_result = usage_error_result(
         @cmd,
         "Could not delete location parameter",
@@ -96,11 +98,13 @@ describe "parameters" do
       )
 
       api_expects_no_call
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
     it "should print error when the parameter doesn't exist" do
+      params = ['--name=A', '--location-id=3']
+
       api_expects(:parameters, :index, 'Find parameter') do |par|
         par['location_id'].to_i == 3
       end.returns(index_response([]))
@@ -111,12 +115,13 @@ describe "parameters" do
         "parameter not found"
       )
 
-      @params = ['--name=A', '--location-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
     it "should delete the parameter" do
+      params = ['--name=A', '--location-id=3']
+
       api_expects(:parameters, :index, 'Find parameter') do |par|
         par['location_id'].to_i == 3
       end.returns(index_response([param]))
@@ -128,8 +133,7 @@ describe "parameters" do
         "Parameter [A] deleted\n"
       )
 
-      @params = ['--name=A', '--location-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
   end

--- a/test/functional/organization_test.rb
+++ b/test/functional/organization_test.rb
@@ -18,11 +18,11 @@ describe "parameters" do
 
     before do
       @cmd = ["organization", "set-parameter"]
-      @params = []
     end
 
     it "should print error on missing --name" do
-      @params = ['--value=1']
+      params = ['--value=1']
+
       expected_result = usage_error_result(
         @cmd,
         "Could not set organization parameter",
@@ -30,12 +30,13 @@ describe "parameters" do
       )
 
       api_expects_no_call
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
     it "should print error on missing --value" do
-      @params = ['--name=A']
+      params = ['--name=A']
+
       expected_result = usage_error_result(
         @cmd,
         "Could not set organization parameter",
@@ -43,12 +44,13 @@ describe "parameters" do
       )
 
       api_expects_no_call
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
 
     it "should create new parameter" do
+      params = ['--name=A', '--value=1', '--organization-id=3']
 
       api_expects(:parameters, :index, 'Attempt find parameters') do |par|
         par['organization_id'].to_i == 3
@@ -58,13 +60,14 @@ describe "parameters" do
         par['parameter']['value'] == '1'
       end.returns({:name => 'A', :value => '1'})
 
-      @params = ['--name=A', '--value=1', '--organization-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(success_result("Parameter [A] created with value [1]\n"), result)
     end
 
 
     it "should update existing parameter" do
+      params = ['--name=A', '--value=1', '--organization-id=3']
+
       api_expects(:parameters, :index, 'Find parameter') do |par|
         par['organization_id'].to_i == 3
       end.returns(index_response([param]))
@@ -74,9 +77,7 @@ describe "parameters" do
         par['parameter']['value'] == '1'
       end.returns({:name => 'A', :value => '1'})
 
-
-      @params = ['--name=A', '--value=1', '--organization-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(success_result("Parameter [A] updated to value [1]\n"), result)
     end
   end
@@ -85,10 +86,11 @@ describe "parameters" do
   describe "delete" do
     before do
       @cmd = ["organization", "delete-parameter"]
-      @params = []
     end
 
     it "should print error on missing --name" do
+      params = []
+
       expected_result = usage_error_result(
         @cmd,
         "Could not delete organization parameter",
@@ -96,11 +98,13 @@ describe "parameters" do
       )
 
       api_expects_no_call
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
     it "should print error when the parameter doesn't exist" do
+      params = ['--name=A', '--organization-id=3']
+
       api_expects(:parameters, :index, 'Find parameter') do |par|
         par['organization_id'].to_i == 3
       end.returns(index_response([]))
@@ -111,12 +115,13 @@ describe "parameters" do
         "parameter not found"
       )
 
-      @params = ['--name=A', '--organization-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
 
     it "should delete the parameter" do
+      params = ['--name=A', '--organization-id=3']
+
       api_expects(:parameters, :index, 'Find parameter') do |par|
         par['organization_id'].to_i == 3
       end.returns(index_response([param]))
@@ -128,8 +133,7 @@ describe "parameters" do
         "Parameter [A] deleted\n"
       )
 
-      @params = ['--name=A', '--organization-id=3']
-      result = run_cmd(@cmd + @params)
+      result = run_cmd(@cmd + params)
       assert_cmd(expected_result, result)
     end
   end

--- a/test/functional/organization_test.rb
+++ b/test/functional/organization_test.rb
@@ -1,0 +1,136 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+
+describe "parameters" do
+
+  let(:param) do
+    {
+      "priority" => nil,
+      "created_at" => "2015-12-03T01:57:55Z",
+      "updated_at" => "2015-12-03T01:57:55Z",
+      "id" => 15,
+      "name" => "B",
+      "value" => "2"
+    }
+  end
+
+  describe "set" do
+
+    before do
+      @cmd = ["organization", "set-parameter"]
+      @params = []
+    end
+
+    it "should print error on missing --name" do
+      @params = ['--value=1']
+      expected_result = usage_error_result(
+        @cmd,
+        "Could not set organization parameter",
+        "option '--name' is required"
+      )
+
+      api_expects_no_call
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+    it "should print error on missing --value" do
+      @params = ['--name=A']
+      expected_result = usage_error_result(
+        @cmd,
+        "Could not set organization parameter",
+        "option '--value' is required"
+      )
+
+      api_expects_no_call
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+
+    it "should create new parameter" do
+
+      api_expects(:parameters, :index, 'Attempt find parameters') do |par|
+        par['organization_id'].to_i == 3
+      end.returns(index_response([]))
+      api_expects(:parameters, :create, 'Create parameter') do |par|
+        par['parameter']['name'] == 'A' &&
+        par['parameter']['value'] == '1'
+      end.returns({:name => 'A', :value => '1'})
+
+      @params = ['--name=A', '--value=1', '--organization-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(success_result("Parameter [A] created with value [1]\n"), result)
+    end
+
+
+    it "should update existing parameter" do
+      api_expects(:parameters, :index, 'Find parameter') do |par|
+        par['organization_id'].to_i == 3
+      end.returns(index_response([param]))
+      api_expects(:parameters, :update, 'Update parameter') do |par|
+        par['id'].to_i == 15 &&
+        par['organization_id'].to_i == 3 &&
+        par['parameter']['value'] == '1'
+      end.returns({:name => 'A', :value => '1'})
+
+
+      @params = ['--name=A', '--value=1', '--organization-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(success_result("Parameter [A] updated to value [1]\n"), result)
+    end
+  end
+
+
+  describe "delete" do
+    before do
+      @cmd = ["organization", "delete-parameter"]
+      @params = []
+    end
+
+    it "should print error on missing --name" do
+      expected_result = usage_error_result(
+        @cmd,
+        "Could not delete organization parameter",
+        "option '--name' is required"
+      )
+
+      api_expects_no_call
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+    it "should print error when the parameter doesn't exist" do
+      api_expects(:parameters, :index, 'Find parameter') do |par|
+        par['organization_id'].to_i == 3
+      end.returns(index_response([]))
+
+      expected_result = common_error_result(
+        @cmd,
+        "Could not delete organization parameter",
+        "parameter not found"
+      )
+
+      @params = ['--name=A', '--organization-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+
+    it "should delete the parameter" do
+      api_expects(:parameters, :index, 'Find parameter') do |par|
+        par['organization_id'].to_i == 3
+      end.returns(index_response([param]))
+      api_expects(:parameters, :destroy, 'Delete parameter') do |par|
+        par['id'] == param['id']
+      end.returns({:name => 'A', :value => '1'})
+
+      expected_result = success_result(
+        "Parameter [A] deleted\n"
+      )
+
+      @params = ['--name=A', '--organization-id=3']
+      result = run_cmd(@cmd + @params)
+      assert_cmd(expected_result, result)
+    end
+  end
+end

--- a/test/functional/test_helper.rb
+++ b/test/functional/test_helper.rb
@@ -1,0 +1,7 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+
+require File.join(File.dirname(__FILE__), 'command_assertions')
+require File.join(File.dirname(__FILE__), 'api_expectations')
+
+include CommandAssertions
+include APIExpectations

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,25 @@
+require 'simplecov'
+require 'pathname'
+
+SimpleCov.use_merging true
+SimpleCov.start do
+  command_name 'MiniTest'
+  add_filter 'test'
+end
+SimpleCov.root Pathname.new(File.dirname(__FILE__) + "../../../")
+
+
+require 'minitest/autorun'
+require 'minitest/spec'
+require "minitest-spec-context"
+require "mocha/setup"
+
+require 'hammer_cli'
+require 'hammer_cli_foreman/commands'
+
+HammerCLIForeman.stubs(:resource_config).returns({
+  :apidoc_cache_dir => 'test/unit/data/' + (ENV['TEST_API_VERSION'] || '1.7'),
+  :apidoc_cache_name => 'foreman_api',
+  :dry_run => true})
+
+require 'hammer_cli_foreman'

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -1,30 +1,4 @@
-require 'simplecov'
-require 'pathname'
-
-SimpleCov.use_merging true
-SimpleCov.start do
-  command_name 'MiniTest'
-  add_filter 'test'
-end
-SimpleCov.root Pathname.new(File.dirname(__FILE__) + "../../../")
-
-
-require 'minitest/autorun'
-require 'minitest/spec'
-require "minitest-spec-context"
-require "mocha/setup"
-
-
-require 'hammer_cli'
-require 'hammer_cli_foreman/commands'
-
-HammerCLIForeman.stubs(:resource_config).returns({
-  :apidoc_cache_dir => 'test/unit/data/' + (ENV['TEST_API_VERSION'] || '1.7'),
-  :apidoc_cache_name => 'foreman_api',
-  :dry_run => true})
-
-
-require 'hammer_cli_foreman'
+require File.join(File.dirname(__FILE__), '../test_helper')
 
 def ctx
   {


### PR DESCRIPTION
- parameter commands for organizations and locations
- common foundation for functional tests
- base parameter commands updated to enable for displaying names and values in messages