### PR TITLE
fixes #13064- Executing "hammer role filters" command throws SQL errors

### DIFF
--- a/lib/hammer_cli_foreman/role.rb
+++ b/lib/hammer_cli_foreman/role.rb
@@ -33,7 +33,7 @@ module HammerCLIForeman
       command_name "filters"
       resource :filters, :index
 
-      option "--id", "ID", _("User role id"), :referenced_resource => 'role', :required => true
+      option "--id", "ID", _("User role id"), :referenced_resource => 'role'
 
       output HammerCLIForeman::Filter::ListCommand.output_definition
 
@@ -52,6 +52,10 @@ module HammerCLIForeman
       build_options do |o|
         o.expand.primary(:roles)
         o.without(:search)
+      end
+
+      def validate_options
+        validator.any(:option_name, :option_id).required
       end
     end
 

--- a/lib/hammer_cli_foreman/role.rb
+++ b/lib/hammer_cli_foreman/role.rb
@@ -33,7 +33,7 @@ module HammerCLIForeman
       command_name "filters"
       resource :filters, :index
 
-      option "--id", "ID", _("User role id"), :referenced_resource => 'role'
+      option "--id", "ID", _("User role id"), :referenced_resource => 'role', :required => true
 
       output HammerCLIForeman::Filter::ListCommand.output_definition
 


### PR DESCRIPTION
Execute hammer role filters throws sql error

PGError: ERROR:  invalid input syntax for integer: ""
LINE 1: ..."id" = "filters"."role_id" WHERE (("roles"."id" = '')) ORDER...
                                                                                         ^
: SELECT  "filters"."id" AS t0_r0, "filters"."search" AS t0_r1, "filters"."role_id" AS t0_r2, "filters"."created_at" AS t0_r3, "filters"."updated_at" AS t0_r4, "filters"."taxonomy_search" AS t0_r5, "roles"."id" AS t1_r0, "roles"."name" AS t1_r1, "roles"."builtin" AS t1_r2, "roles"."permissions" AS t1_r3 FROM "filters" LEFT OUTER JOIN "roles" ON "roles"."id" = "filters"."role_id" WHERE (("roles"."id" = '')) ORDER BY role_id, filters.id LIMIT 20 OFFSET 0
