### PR TITLE
Fixes #12998 - hammer listing the sc-params shows puppetclass

### DIFF
--- a/lib/hammer_cli_foreman/smart_class_parameter.rb
+++ b/lib/hammer_cli_foreman/smart_class_parameter.rb
@@ -32,10 +32,8 @@ module HammerCLIForeman
   class SmartClassParametersList < SmartClassParametersBriefList
 
     output do
-      from :puppetclass do
-        field :name, _("Puppet class")
-        field :id, _("Class Id"), Fields::Id
-      end
+      field :puppetclass_name, _("Puppet class")
+      field :puppetclass_id, _("Class Id"), Fields::Id
     end
   end
 


### PR DESCRIPTION
This will only work after: https://github.com/theforeman/foreman/pull/3045 is merged.