### PR TITLE
Fixes #11880 - Added special method for dealing with puppetclasses

### DIFF
--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -119,7 +119,7 @@ module HammerCLIForeman
     end
 
     def puppetclass_ids(options)
-      options[HammerCLI.option_accessor_name("ids")] || find_resources(:puppetclasses, options).collect{|h| h.values}.flatten.map{|h| h['id']}
+      options[HammerCLI.option_accessor_name("ids")] || find_puppetclasses(options).values.collect { |c| c.first['id'] }
     end
 
     protected
@@ -150,6 +150,14 @@ module HammerCLIForeman
     def find_resources(resource_name, options)
       resource = @api.resource(resource_name)
       results = resolved_call(resource_name, :index, options)
+      raise ResolverError.new(_("one of %s not found") % resource.name, resource) if results.count < expected_record_count(options, resource)
+      results
+    end
+
+    def find_puppetclasses(options)
+      resource_name = :puppetclasses
+      resource = @api.resource(resource_name)
+      results = resolved_call(resource_name, :index, options).first
       raise ResolverError.new(_("one of %s not found") % resource.name, resource) if results.count < expected_record_count(options, resource)
       results
     end


### PR DESCRIPTION
Puppetclasses API call is using a different format for the output - it uses a hash instead of an array of results.
Created a method that would deal with puppetclasses output.