### PR TITLE
Fixes #11147 - Handle API request redirects with useful message

### DIFF
--- a/config/foreman.yml
+++ b/config/foreman.yml
@@ -14,3 +14,7 @@
 
   # API request timeout. Set to -1 for no timeout
   #:request_timeout: 120 #seconds
+
+  # Follow API redirects. One of :never, :default, :always
+  # Value :default means RestClient default behaviour - follow only in GET and HEAD requests
+  #:follow_redirects: :never

--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -23,5 +23,6 @@ EOF
   s.require_paths = ["lib"]
 
   s.add_dependency 'hammer_cli', '>= 0.6.0'
+  s.add_dependency 'apipie-bindings', '>=0.0.16'
 
 end

--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -25,6 +25,7 @@ module HammerCLIForeman
     config[:credentials] = credentials
     config[:logger] = Logging.logger['API']
     config[:api_version] = 2
+    config[:follow_redirects] = HammerCLI::Settings.get(:foreman, :follow_redirects) || :never
     config[:aggressive_cache_checking] = HammerCLI::Settings.get(:foreman, :refresh_cache) || false
     config[:headers] = { "Accept-Language" => HammerCLI::I18n.locale }
     config[:language] = HammerCLI::I18n.locale

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -115,5 +115,24 @@ describe HammerCLIForeman::ExceptionHandler do
     err_code.must_equal HammerCLI::EX_SOFTWARE
   end
 
-end
+  context "redirects" do
+    let(:response) { HammerCLIForeman.foreman_api.send(:create_fake_response, 301, '', 'GET', 'http://foreman.example.com/api/architectures') }
+    it "should detect http to https redirection error" do
+      response.headers[:location] = 'https://foreman.example.com/api/architectures'
+      ex = RestClient::MovedPermanently.new(response)
 
+      output.expects(:print_error).with(heading, "Redirection of API call detected.\nIt seems hammer is configured to use HTTP and the server prefers HTTPS.\nUpdate your server url configuration\nyou can set 'follow_redirects' to one of :default or :always to enable redirects following")
+      err_code = handler.handle_exception(ex, :heading => heading)
+      err_code.must_equal HammerCLI::EX_CONFIG
+    end
+
+    it "should detect redirection error" do
+      response.headers[:location] = 'http://foreman.example.com/api/other_resource'
+      ex = RestClient::MovedPermanently.new(response)
+
+      output.expects(:print_error).with(heading, "Redirection of API call detected.\nUpdate your server url configuration\nyou can set 'follow_redirects' to one of :default or :always to enable redirects following")
+      err_code = handler.handle_exception(ex, :heading => heading)
+      err_code.must_equal HammerCLI::EX_CONFIG
+    end
+  end
+end


### PR DESCRIPTION
- added dependency on apipie-bindings as we require more strict version than core
- set to not follow redirect by default
- detect redirect from HTTP to HTTPS
- add some hints on how to update the config (does it make sense?)
- smaple config updated

How to test: 
run some queries to sat6 or foreman with enabled redirects with protocol set to http.