### PR TITLE
Fixes #13927 - make primary and provision flag optional

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -90,9 +90,6 @@ module HammerCLIForeman
       params['host']['compute_attributes']['volumes_attributes'] = nested_attributes(option_volume_list)
       params['host']['interfaces_attributes'] = interfaces_attributes
 
-      # check primary and provision interfaces, only for create
-      check_mandatory_interfaces(params['host']['interfaces_attributes']) if params['id'].nil?
-
       params['host']['root_pass'] = option_root_password unless option_root_password.nil?
 
       if option_ask_root_password
@@ -146,15 +143,6 @@ module HammerCLIForeman
         end
         nic['compute_attributes'] = compute_attributes unless compute_attributes.empty?
         nic
-      end
-    end
-
-    def check_mandatory_interfaces(nics)
-      unless nics.any? { |key, nic| nic['primary'] == 'true' }
-        signal_usage_error _('At least one interface must be set as primary')
-      end
-      unless nics.any? { |key, nic| nic['provision'] == 'true' }
-        signal_usage_error _('At least one interface must be set as provision')
       end
     end
 


### PR DESCRIPTION
(cherry picked from commit e8a7110e0699cb54875df67b7d454a687acdcc9d)

---

Proposed cherry pick of #13927 to fix ticket http://projects.theforeman.org/issues/14267, seen in 0.6.1 on Foreman 1.11.

Jenkins isn't configured to run tests on 0.6-stable, sorry about that.