### PR TITLE
Fixes #14530 - respect per_page set in config file

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -328,7 +328,7 @@ module HammerCLIForeman
     end
 
     def should_retrieve_all?
-      pagination_supported? && option_per_page.nil? && option_page.nil?
+      pagination_supported? && option_per_page.nil? && option_page.nil? && HammerCLI::Settings.get(:ui, :per_page).nil?
     end
 
   end

--- a/lib/hammer_cli_foreman/testing/api_expectations.rb
+++ b/lib/hammer_cli_foreman/testing/api_expectations.rb
@@ -50,13 +50,13 @@ module HammerCLIForeman
         ApipieBindings::API.any_instance.expects(:call_action).never
       end
 
-      def index_response(items)
+      def index_response(items, options={})
         cnt = items.length
         {
-          "total" => cnt,
-          "subtotal" => cnt,
-          "page" => 1,
-          "per_page" => cnt,
+          "total" => options.fetch(:total, cnt),
+          "subtotal" => options.fetch(:subtotal, cnt),
+          "page" => options.fetch(:page, 1),
+          "per_page" => options.fetch(:per_page, cnt),
           "search" => "",
           "sort" => {
             "by" => nil,

--- a/test/functional/commands/list_test.rb
+++ b/test/functional/commands/list_test.rb
@@ -1,0 +1,52 @@
+require File.join(File.dirname(__FILE__), '..', 'test_helper')
+
+describe "ListCommand" do
+  describe "pagination" do
+    let(:row1) { { :id => '1', :name => 'Name', :type => 'Type' } }
+    let(:row2) { { :id => '2', :name => 'Name', :type => 'Type' } }
+    let(:header) { ['ID', 'NAME', 'TYPE'] }
+    let(:pagination) { ['Page 1 of 2 (use --page and --per-page for navigation)'] }
+    let(:output_without_pagination) { IndexMatcher.new([header, row1.values]) }
+    let(:output_with_pagination) { IndexMatcher.new([header, row1.values, pagination]) }
+
+    it 'prints all rows by default' do
+      expected_result = success_result(output_without_pagination)
+      api_expects(:config_templates, :index, "List all parameters") do |par|
+        par["page"] == 1 && par["per_page"] == 1000
+      end.returns(index_response([row1]))
+
+      result = run_cmd(['template', 'list'], {})
+      assert_cmd(expected_result, result)
+      result.out.wont_match /Page [1-9] of [0-9]/
+    end
+
+    it 'prints one page when --per-page is used' do
+      expected_result = success_result(output_with_pagination)
+      api_expects(:config_templates, :index, "List 1st page") do |par|
+        par["page"].to_i == 1 && par["per_page"].to_i == 1
+      end.returns(index_response([row1], :total => 2, :subtotal => 2, :per_page => 1, :page => 1))
+
+      result = run_cmd(['template', 'list', '--per-page=1'], {})
+      assert_cmd(expected_result, result)
+    end
+
+    context 'in settings' do
+      before :all do
+        HammerCLI::Settings.load({ :ui => { :per_page => '1' } })
+      end
+      after :all do
+        HammerCLI::Settings.load({ :ui => { :per_page => nil } })
+      end
+
+      it 'prints one page when per_page is set in the config' do
+        expected_result = success_result(output_with_pagination)
+        api_expects(:config_templates, :index, "List 1st page") do |par|
+          par["page"].to_i == 1 && par["per_page"].to_i == 1
+        end.returns(index_response([row1], :total => 2, :subtotal => 2, :per_page => 1, :page => 1))
+
+        result = run_cmd(['template', 'list'], {})
+        assert_cmd(expected_result, result)
+      end
+    end
+  end
+end

--- a/test/functional/test_helper.rb
+++ b/test/functional/test_helper.rb
@@ -1,7 +1,10 @@
 require File.join(File.dirname(__FILE__), '../test_helper')
 
 require 'hammer_cli/testing/command_assertions'
+require 'hammer_cli/testing/output_matchers'
+
 require 'hammer_cli_foreman/testing/api_expectations'
 
 include HammerCLI::Testing::CommandAssertions
+include HammerCLI::Testing::OutputMatchers
 include HammerCLIForeman::Testing::APIExpectations


### PR DESCRIPTION
How to test:
$ cat ~/.hammer/cli_config.yml 
```yaml
:ui:
    :history_file: '~/.hammer/history'
    # Enable interactive queries?
    :interactive: true
    # Number of records listed per page
    :per_page: 5
```
Without this patch all records are printed from e.g. `hammer template list`.
With this patch page with 5 records is printed. If hammer core has https://github.com/theforeman/hammer-cli/pull/200 marged information about current page is attached:

```
$ hammer template list
---|----------------------------|----------
ID | NAME                       | TYPE     
---|----------------------------|----------
7  | Alterator default          | provision
8  | Alterator default finish   | finish   
9  | Alterator default PXELinux | PXELinux 
41 | alterator_pkglist          | snippet  
10 | Atomic Kickstart default   | provision
---|----------------------------|----------
Page 1 of 13 (use --page and --per-page for navigation)
```