### PR TITLE
Fixes #14466 - add support for Gemfile.local.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ruby
 Gemfile.lock
 Gemfile.local
+Gemfile.local.rb
 pkg
 .bundle
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,7 @@ group :test do
 end
 
 # load local gemfile
-local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
-self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
+['Gemfile.local.rb', 'Gemfile.local'].map do |file_name|
+  local_gemfile = File.join(File.dirname(__FILE__), file_name)
+  self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
+end


### PR DESCRIPTION
The change keeps backward compatibility with `Gemfile.local`