### PR TITLE
Document vmware `start` parameter

### DIFF
--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -233,7 +233,7 @@ path                 # path to folder
 guest_id             # guest OS id form VMware
 scsi_controller_type # id of the controller from VMWare
 hardware_version     # hardware version id from VMWare
-start                # 1/0
+start                # Must be a 1 or 0, whether to start the machine or not
 ```
 
 Available keys for `--interface`:


### PR DESCRIPTION
In our testing "true" didn't work like the foreman docs show for other REST parameters. `start` must be `"1"` for the VM to start so make these docs extra clear since they are the only docs on the entire internet we could find for this parameter..