### PR TITLE
Fixes #15833 - add filtering by env to smart class parameter id resolver

### DIFF
--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -254,6 +254,9 @@ module HammerCLIForeman
       value = options[HammerCLI.option_accessor_name('name')]
       search_options[:search] = "key = \"#{value}\""
       search_options[:puppetclass_id] = puppetclass_id(scoped_options("puppetclass", options))
+      if (options[HammerCLI.option_accessor_name("environment_id")] || options[HammerCLI.option_accessor_name("environment_name")])
+        search_options[:environment_id] = environment_id(scoped_options("environment", options))
+      end
       search_options
     end
 

--- a/lib/hammer_cli_foreman/smart_class_parameter.rb
+++ b/lib/hammer_cli_foreman/smart_class_parameter.rb
@@ -87,7 +87,7 @@ module HammerCLIForeman
       end
 
       build_options do |options|
-        options.expand.including(:puppetclasses)
+        options.expand.including(:puppetclasses, :environments)
       end
 
       validate_options do
@@ -103,7 +103,7 @@ module HammerCLIForeman
       failure_message _("Could not update the parameter")
 
       build_options do |options|
-        options.expand.including(:puppetclasses)
+        options.expand.including(:puppetclasses, :environments)
         options.without(:parameter_type, :validator_type, :override, :required)
       end
 

--- a/test/unit/smart_class_parameter_test.rb
+++ b/test/unit/smart_class_parameter_test.rb
@@ -50,6 +50,7 @@ describe HammerCLIForeman::SmartClassParameter do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "name, puppet-class", ["--name=par", "--puppet-class=ntp"]
+      it_should_accept "name, puppet-class, env", ["--name=par", "--puppet-class=ntp", "--environment=development"]
       it_should_fail_with "name", ["--name=par"]
       # it_should_fail_with "no arguments"
       # TODO: temporarily disabled, parameters are checked in the id resolver
@@ -64,6 +65,7 @@ describe HammerCLIForeman::SmartClassParameter do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "name, puppet-class", ["--name=par", "--puppet-class=ntp"]
+      it_should_accept "name, puppet-class, env", ["--name=par", "--puppet-class=ntp", "--environment=development"]
       it_should_fail_with "name", ["--name=par"]
       it_should_accept "override", ["--id=1","--override=true"]
       it_should_accept "description", ["--id=1","--description=descr"]


### PR DESCRIPTION
When there is the same class imported from multiple environments
its parameters are listed for each of the respective environments.
This patch is adding filtering by --environemnt-id (--environment)
to sc-param update and info commands.