### PR TITLE
Refs #12473 - show admin flag in user-group listing

### DIFF
--- a/lib/hammer_cli_foreman/usergroup.rb
+++ b/lib/hammer_cli_foreman/usergroup.rb
@@ -10,6 +10,7 @@ module HammerCLIForeman
       output do
         field :id, _("Id")
         field :name, _("Name")
+        field :admin, _("Admin"), Fields::Boolean
       end
 
       build_options
@@ -57,6 +58,3 @@ module HammerCLIForeman
   end
 
 end
-
-
-

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -20,6 +20,7 @@ describe HammerCLIForeman::Usergroup do
     context "output" do
       it_should_print_column "Id"
       it_should_print_column "Name"
+      it_should_print_column "Admin"
     end
 
   end
@@ -37,6 +38,7 @@ describe HammerCLIForeman::Usergroup do
       with_params ["--id=1"] do
         it_should_print_column "Id"
         it_should_print_column "Name"
+        it_should_print_column "Admin"
         it_should_print_column "Users"
         it_should_print_column "User groups"
         it_should_print_column "Roles"


### PR DESCRIPTION
The API already sends the admin flag in its responses so no changes on the server side are not necessary.
Note: to create admin user group with hammer you will need https://github.com/theforeman/foreman/pull/3705 merged in though.