### PR TITLE
Fixes #16141 - pin fast_gettext to < 1.1.0 for ruby < 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
+if RUBY_VERSION < '2.1.0'
+  gem 'fast_gettext', '< 1.2.0'
+end
 
 group :test do
   gem 'rake', '~> 10.1.0'


### PR DESCRIPTION
fast_gettext 1.2.0 drops support for ruby 2.0 and below