### PR TITLE
Fixes #12472 - compute resource specific details in host help

### DIFF
--- a/lib/hammer_cli_foreman/compute_resources/all.rb
+++ b/lib/hammer_cli_foreman/compute_resources/all.rb
@@ -1,0 +1,7 @@
+require 'hammer_cli_foreman/compute_resources/ec2'
+require 'hammer_cli_foreman/compute_resources/gce'
+require 'hammer_cli_foreman/compute_resources/libvirt'
+require 'hammer_cli_foreman/compute_resources/openstack'
+require 'hammer_cli_foreman/compute_resources/ovirt'
+require 'hammer_cli_foreman/compute_resources/rackspace'
+require 'hammer_cli_foreman/compute_resources/vmware'

--- a/lib/hammer_cli_foreman/compute_resources/ec2.rb
+++ b/lib/hammer_cli_foreman/compute_resources/ec2.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/compute_resources/ec2/host_help_extenstion'
+
+module HammerCLIForeman
+  module ComputeResources
+    module EC2
+      HammerCLIForeman::Host.extend_cr_help(HostHelpExtenstion.new)
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/ec2/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/ec2/host_help_extenstion.rb
@@ -1,0 +1,23 @@
+module HammerCLIForeman
+  module ComputeResources
+    module EC2
+      class HostHelpExtenstion
+        def name
+          _('EC2')
+        end
+
+        def host_create_help(h)
+          h.section '--compute-attributes' do |h|
+            h.list([
+              'flavor_id',
+              'image_id',
+              'availability_zone',
+              'security_group_ids',
+              'managed_ip',
+            ])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/gce.rb
+++ b/lib/hammer_cli_foreman/compute_resources/gce.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/compute_resources/gce/host_help_extenstion'
+
+module HammerCLIForeman
+  module ComputeResources
+    module GCE
+      HammerCLIForeman::Host.extend_cr_help(HostHelpExtenstion.new)
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/gce/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/gce/host_help_extenstion.rb
@@ -1,0 +1,22 @@
+module HammerCLIForeman
+  module ComputeResources
+    module GCE
+      class HostHelpExtenstion
+        def name
+          _('GCE')
+        end
+
+        def host_create_help(h)
+          h.section '--compute-attributes' do |h|
+            h.list([
+              'machine_type',
+              'image_id',
+              'network',
+              'external_ip'
+            ])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/libvirt.rb
+++ b/lib/hammer_cli_foreman/compute_resources/libvirt.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/compute_resources/libvirt/host_help_extenstion'
+
+module HammerCLIForeman
+  module ComputeResources
+    module Libvirt
+      HammerCLIForeman::Host.extend_cr_help(HostHelpExtenstion.new)
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/libvirt/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/libvirt/host_help_extenstion.rb
@@ -1,0 +1,35 @@
+module HammerCLIForeman
+  module ComputeResources
+    module Libvirt
+      class HostHelpExtenstion
+        def name
+          _('Libvirt')
+        end
+
+        def host_create_help(h)
+          h.section '--compute-attributes' do |h|
+            h.list([
+              ['cpus',   _('Number of CPUs')],
+              ['memory', _('String, amount of memory, value in bytes')],
+              ['start',  _('Boolean, whether to start the machine or not')]
+            ])
+          end
+          h.section '--interface' do |h|
+            h.list([
+              ['compute_type',                     _('Possible values: %s') % 'bridge, network'],
+              ['compute_network / compute_bridge', _('Name of interface according to type')],
+              ['compute_model',                    _('Possible values: %s') % 'virtio, rtl8139, ne2k_pci, pcnet, e1000']
+            ])
+          end
+          h.section '--volume' do |h|
+            h.list([
+              ['pool_name',   _('One of available storage pools')],
+              ['capacity',    _('String value, eg. 10G')],
+              ['format_type', _('Possible values: %s') % 'raw, qcow2']
+            ])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/openstack.rb
+++ b/lib/hammer_cli_foreman/compute_resources/openstack.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/compute_resources/openstack/host_help_extenstion'
+
+module HammerCLIForeman
+  module ComputeResources
+    module OpenStack
+      HammerCLIForeman::Host.extend_cr_help(HostHelpExtenstion.new)
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/openstack/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/openstack/host_help_extenstion.rb
@@ -1,0 +1,23 @@
+module HammerCLIForeman
+  module ComputeResources
+    module OpenStack
+      class HostHelpExtenstion
+        def name
+          _('OpenStack')
+        end
+
+        def host_create_help(h)
+          h.section '--compute-attributes' do |h|
+            h.list([
+              'flavor_ref',
+              'image_ref',
+              'tenant_id',
+              'security_groups',
+              'network'
+            ])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/ovirt.rb
+++ b/lib/hammer_cli_foreman/compute_resources/ovirt.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/compute_resources/ovirt/host_help_extenstion'
+
+module HammerCLIForeman
+  module ComputeResources
+    module Ovirt
+      HammerCLIForeman::Host.extend_cr_help(HostHelpExtenstion.new)
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/ovirt/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/ovirt/host_help_extenstion.rb
@@ -1,0 +1,36 @@
+module HammerCLIForeman
+  module ComputeResources
+    module Ovirt
+      class HostHelpExtenstion
+        def name
+          _('oVirt')
+        end
+
+        def host_create_help(h)
+          h.section '--compute-attributes' do |h|
+            h.list([
+              ['cluster'],
+              ['template', _('Hardware profile to use')],
+              ['cores',    _('Integer value, number of cores')],
+              ['memory',   _('Amount of memory, integer value in bytes')],
+              ['start',    _('Boolean, whether to start the machine or not')]
+            ])
+          end
+          h.section '--interface' do |h|
+            h.list([
+              ['compute_name',    _('Eg. eth0')],
+              ['compute_network', _('Select one of available networks for a cluster')]
+            ])
+          end
+          h.section '--volume' do |h|
+            h.list([
+              ['size_gb',        _('Volume size in GB, integer value')],
+              ['storage_domain', _('Select one of available storage domains')],
+              ['bootable',       _('Boolean, only one volume can be bootable')]
+            ])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/rackspace.rb
+++ b/lib/hammer_cli_foreman/compute_resources/rackspace.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/compute_resources/rackspace/host_help_extenstion'
+
+module HammerCLIForeman
+  module ComputeResources
+    module Rackspace
+      HammerCLIForeman::Host.extend_cr_help(HostHelpExtenstion.new)
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/rackspace/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/rackspace/host_help_extenstion.rb
@@ -1,0 +1,18 @@
+module HammerCLIForeman
+  module ComputeResources
+    module Rackspace
+      class HostHelpExtenstion
+        def name
+          _('oVirt')
+        end
+
+        def host_create_help(h)
+          h.list([
+            'flavor_id',
+            'image_id'
+          ])
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/vmware.rb
+++ b/lib/hammer_cli_foreman/compute_resources/vmware.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/compute_resources/vmware/host_help_extenstion'
+
+module HammerCLIForeman
+  module ComputeResources
+    module VMware
+      HammerCLIForeman::Host.extend_cr_help(HostHelpExtenstion.new)
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/vmware/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/vmware/host_help_extenstion.rb
@@ -1,0 +1,62 @@
+module HammerCLIForeman
+  module ComputeResources
+    module VMware
+      class HostHelpExtenstion
+        INTERFACE_TYPES = %w(
+          VirtualVmxnet,
+          VirtualVmxnet2,
+          VirtualVmxnet3,
+          VirtualE1000,
+          VirtualE1000e,
+          VirtualPCNet32
+        )
+
+        def name
+          _('VMWare')
+        end
+
+        def host_create_help(h)
+          h.section '--compute-attributes' do |h|
+            h.list([
+              ['cpus',                 _("Cpu count")],
+              ['corespersocket',       _("Number of cores per socket (applicable to hardware versions < 10 only)")],
+              ['memory_mb',            _("Integer number, amount of memory in MB")],
+              ['cluster',              _("Cluster id from VMware")],
+              ['path',                 _("Path to folder")],
+              ['guest_id',             _("Guest OS id form VMware")],
+              ['scsi_controller_type', _("Id of the controller from VMware")],
+              ['hardware_version',     _("Hardware version id from VMware")],
+              ['start',                _("Must be a 1 or 0, whether to start the machine or not")]
+            ])
+          end
+          h.section '--interface' do |h|
+            h.list([
+              ['compute_type', interface_type_description(h)],
+              ['compute_network', _('Network id from VMware')]
+            ])
+          end
+          h.section '--volume' do |h|
+            h.list([
+              ['name'],
+              ['datastore',  _('Datastore id from VMware')],
+              ['size_gb',    _('Integer number, volume size in GB')],
+              ['thin',       'true/false'],
+              ['eager_zero', 'true/false']
+            ])
+          end
+        end
+
+        private
+
+        def interface_type_description(h)
+          [
+            _('Type of the network adapter, for example one of:'),
+            h.indent(INTERFACE_TYPES),
+            _("See documentation center for your version of vSphere to find more details about available adapter types:"),
+            h.indent("https://www.vmware.com/support/pubs/")
+          ].join("\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -4,154 +4,25 @@ require 'hammer_cli_foreman/puppet_class'
 require 'hammer_cli_foreman/smart_class_parameter'
 require 'hammer_cli_foreman/smart_variable'
 require 'hammer_cli_foreman/interface'
+require 'hammer_cli_foreman/hosts/common_update_options'
+require 'hammer_cli_foreman/hosts/common_update_help'
 
 require 'highline/import'
 
 module HammerCLIForeman
 
-  module CommonHostUpdateOptions
-
-    def self.included(base)
-      base.option "--owner", "OWNER_LOGIN", _("Login of the owner"),
-        :attribute_name => :option_user_login
-      base.option "--owner-id", "OWNER_ID", _("ID of the owner"),
-        :attribute_name => :option_user_id
-
-      base.option "--root-password", "ROOT_PW", " "
-      base.option "--ask-root-password", "ASK_ROOT_PW", " ",
-        :format => HammerCLI::Options::Normalizers::Bool.new
-
-      base.option "--puppet-proxy", "PUPPET_PROXY_NAME", ""
-      base.option "--puppet-ca-proxy", "PUPPET_CA_PROXY_NAME", ""
-      base.option "--puppet-class-ids", "PUPPET_CLASS_IDS", "",
-        :format => HammerCLI::Options::Normalizers::List.new,
-        :attribute_name => :option_puppetclass_ids
-      base.option "--puppet-classes", "PUPPET_CLASS_NAMES", "",
-        :format => HammerCLI::Options::Normalizers::List.new
-
-      bme_options = {}
-      bme_options[:default] = 'true' if base.action.to_sym == :create
-
-      bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
-      base.option "--managed", "MANAGED", " ", bme_options
-      bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
-      base.option "--build", "BUILD", " ", bme_options
-      bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
-      base.option "--enabled", "ENABLED", " ",  bme_options
-      bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
-      base.option "--overwrite", "OVERWRITE", " ",  bme_options
-
-      base.option "--parameters", "PARAMS", _("Host parameters."),
-        :format => HammerCLI::Options::Normalizers::KeyValueList.new
-      base.option "--compute-attributes", "COMPUTE_ATTRS", _("Compute resource attributes."),
-        :format => HammerCLI::Options::Normalizers::KeyValueList.new
-      base.option "--volume", "VOLUME", _("Volume parameters"), :multivalued => true,
-        :format => HammerCLI::Options::Normalizers::KeyValueList.new
-      base.option "--interface", "INTERFACE", _("Interface parameters."), :multivalued => true,
-        :format => HammerCLI::Options::Normalizers::KeyValueList.new
-      base.option "--provision-method", "METHOD", " ",
-        :format => HammerCLI::Options::Normalizers::Enum.new(['build', 'image'])
-
-      base.build_options :without => [
-            # - temporarily disabled params that will be removed from the api ------------------
-            :provision_method, :capabilities, :flavour_ref, :image_ref, :start,
-            :network, :cpus, :memory, :provider, :type, :tenant_id, :image_id,
-            # ----------------------------------------------------------------------------------
-            :puppet_class_ids, :host_parameters_attributes, :interfaces_attributes]
-    end
-
-    def self.ask_password
-      prompt = _("Enter the root password for the host:") + " "
-      ask(prompt) {|q| q.echo = false}
-    end
-
-    def request_params
-      params = super
-
-      owner_id = get_resource_id(HammerCLIForeman.foreman_resource(:users), :required => false, :scoped => true)
-      params['host']['owner_id'] ||= owner_id unless owner_id.nil?
-
-      puppet_proxy_id = proxy_id(option_puppet_proxy)
-      params['host']['puppet_proxy_id'] ||= puppet_proxy_id unless puppet_proxy_id.nil?
-
-      puppet_ca_proxy_id = proxy_id(option_puppet_ca_proxy)
-      params['host']['puppet_ca_proxy_id'] ||= puppet_ca_proxy_id unless puppet_ca_proxy_id.nil?
-
-      puppetclass_ids = option_puppetclass_ids || puppet_class_ids(option_puppet_classes)
-      params['host']['puppetclass_ids'] = puppetclass_ids unless puppetclass_ids.nil?
-
-      params['host']['build'] = option_build unless option_build.nil?
-      params['host']['managed'] = option_managed unless option_managed.nil?
-      params['host']['enabled'] = option_enabled unless option_enabled.nil?
-      params['host']['overwrite'] = option_overwrite unless option_overwrite.nil?
-
-      params['host']['host_parameters_attributes'] = parameter_attributes
-      params['host']['compute_attributes'] = option_compute_attributes || {}
-      params['host']['compute_attributes']['volumes_attributes'] = nested_attributes(option_volume_list)
-      params['host']['interfaces_attributes'] = interfaces_attributes
-
-      params['host']['root_pass'] = option_root_password unless option_root_password.nil?
-
-      if option_ask_root_password
-        params['host']['root_pass'] = HammerCLIForeman::CommonHostUpdateOptions::ask_password
-      end
-
-      params
-    end
-
-    private
-
-    def proxy_id(name)
-      resolver.smart_proxy_id('option_name' => name) if name
-    end
-
-    def puppet_class_ids(names)
-      resolver.puppetclass_ids('option_names' => names) if names
-    end
-
-    def parameter_attributes
-      return {} unless option_parameters
-      option_parameters.collect do |key, value|
-        if value.is_a? String
-          {"name"=>key, "value"=>value}
-        else
-          {"name"=>key, "value"=>value.inspect}
-        end
-      end
-    end
-
-    def nested_attributes(attrs)
-      return {} unless attrs
-
-      nested_hash = {}
-      attrs.each_with_index do |attr, i|
-        nested_hash[i.to_s] = attr
-      end
-      nested_hash
-    end
-
-    def interfaces_attributes
-      return {} if option_interface_list.empty?
-
-      # move each attribute starting with "compute_" to compute_attributes
-      option_interface_list.collect do |nic|
-        compute_attributes = {}
-        nic.keys.each do |key|
-          if key.start_with? 'compute_'
-            compute_attributes[key.gsub('compute_', '')] = nic.delete(key)
-          end
-        end
-        nic['compute_attributes'] = compute_attributes unless compute_attributes.empty?
-        nic
-      end
-    end
-
-  end
-
 
   class Host < HammerCLIForeman::Command
 
     resource :hosts
+
+    def self.extend_cr_help(cr)
+      cr_help_extensions[cr.name] = cr.method(:host_create_help)
+    end
+
+    def self.cr_help_extensions
+      @cr_help_extensions ||= {}
+    end
 
     class ListCommand < HammerCLIForeman::ListCommand
       # FIXME: list compute resource (model)
@@ -357,7 +228,8 @@ module HammerCLIForeman
       success_message _("Host created")
       failure_message _("Could not create the host")
 
-      include HammerCLIForeman::CommonHostUpdateOptions
+      include HammerCLIForeman::Hosts::CommonUpdateOptions
+      include HammerCLIForeman::Hosts::CommonUpdateHelp
 
       def validate_options
         super
@@ -368,14 +240,15 @@ module HammerCLIForeman
           end
         end
       end
-    end
 
+    end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
       success_message _("Host updated")
       failure_message _("Could not update the host")
 
-      include HammerCLIForeman::CommonHostUpdateOptions
+      include HammerCLIForeman::Hosts::CommonUpdateOptions
+      include HammerCLIForeman::Hosts::CommonUpdateHelp
     end
 
 
@@ -524,3 +397,5 @@ module HammerCLIForeman
   end
 
 end
+
+require 'hammer_cli_foreman/compute_resources/all'

--- a/lib/hammer_cli_foreman/hosts/common_update_help.rb
+++ b/lib/hammer_cli_foreman/hosts/common_update_help.rb
@@ -3,7 +3,7 @@ module HammerCLIForeman
     module CommonUpdateHelp
       def self.included(base)
         base.extend_help do |h|
-          h.section 'Available keys for --interface' do |h|
+          h.section _('Available keys for %{option}') % { :option => '--interface' } do |h|
             h.list([
               'mac',
               'ip',
@@ -17,20 +17,20 @@ module HammerCLIForeman
               ['provision', 'true/false'],
               ['virtual',   'true/false']
             ])
-            h.section 'For virtual=true' do |h|
+            h.section _('For %{condition}') % { :condition => 'virtual=true' } do |h|
               h.list([
                 ['tag',         _('VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces.')],
                 ['attached_to', _('Identifier of the interface to which this interface belongs, e.g. eth1.')]
               ])
             end
-            h.section 'For type=bond' do |h|
+            h.section _('For %{condition}') % { :condition => 'type=bond' } do |h|
               h.list([
                 ['mode',             _('Possible values: %s') % 'balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb'],
                 ['attached_devices', _('Identifiers of slave interfaces, e.g. [eth1,eth2]')],
                 'bond_options'
               ])
             end
-            h.section 'For type=bmc' do |h|
+            h.section _('For %{condition}') % { :condition => 'type=bmc' } do |h|
               h.list([
                 ['provider', _('always IPMI')],
                 'username',
@@ -39,7 +39,7 @@ module HammerCLIForeman
             end
           end
 
-          h.section 'Provider specific options' do |h|
+          h.section _('Provider specific options') do |h|
             HammerCLIForeman::Host.cr_help_extensions.each do |name, help|
               h.section name do |h|
                 help.call(h)

--- a/lib/hammer_cli_foreman/hosts/common_update_help.rb
+++ b/lib/hammer_cli_foreman/hosts/common_update_help.rb
@@ -1,0 +1,53 @@
+module HammerCLIForeman
+  module Hosts
+    module CommonUpdateHelp
+      def self.included(base)
+        base.extend_help do |h|
+          h.section 'Available keys for --interface' do |h|
+            h.list([
+              'mac',
+              'ip',
+              ['type',      _('Possible values: %s') % 'interface, bmc, bond, bridge'],
+              'name',
+              'subnet_id',
+              'domain_id',
+              'identifier',
+              ['managed',   'true/false'],
+              ['primary',   _('%{value}, each managed hosts needs to have one primary interface.') % {:value => 'true/false'}],
+              ['provision', 'true/false'],
+              ['virtual',   'true/false']
+            ])
+            h.section 'For virtual=true' do |h|
+              h.list([
+                ['tag',         _('VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces.')],
+                ['attached_to', _('Identifier of the interface to which this interface belongs, e.g. eth1.')]
+              ])
+            end
+            h.section 'For type=bond' do |h|
+              h.list([
+                ['mode',             _('Possible values: %s') % 'balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb'],
+                ['attached_devices', _('Identifiers of slave interfaces, e.g. [eth1,eth2]')],
+                'bond_options'
+              ])
+            end
+            h.section 'For type=bmc' do |h|
+              h.list([
+                ['provider', _('always IPMI')],
+                'username',
+                'password'
+              ])
+            end
+          end
+
+          h.section 'Provider specific options' do |h|
+            HammerCLIForeman::Host.cr_help_extensions.each do |name, help|
+              h.section name do |h|
+                help.call(h)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/hosts/common_update_options.rb
+++ b/lib/hammer_cli_foreman/hosts/common_update_options.rb
@@ -1,0 +1,141 @@
+module HammerCLIForeman
+  module Hosts
+    module CommonUpdateOptions
+
+      def self.included(base)
+        base.option "--owner", "OWNER_LOGIN", _("Login of the owner"),
+          :attribute_name => :option_user_login
+        base.option "--owner-id", "OWNER_ID", _("ID of the owner"),
+          :attribute_name => :option_user_id
+
+        base.option "--root-password", "ROOT_PW", " "
+        base.option "--ask-root-password", "ASK_ROOT_PW", " ",
+          :format => HammerCLI::Options::Normalizers::Bool.new
+
+        base.option "--puppet-proxy", "PUPPET_PROXY_NAME", ""
+        base.option "--puppet-ca-proxy", "PUPPET_CA_PROXY_NAME", ""
+        base.option "--puppet-class-ids", "PUPPET_CLASS_IDS", "",
+          :format => HammerCLI::Options::Normalizers::List.new,
+          :attribute_name => :option_puppetclass_ids
+        base.option "--puppet-classes", "PUPPET_CLASS_NAMES", "",
+          :format => HammerCLI::Options::Normalizers::List.new
+
+        bme_options = {}
+        bme_options[:default] = 'true' if base.action.to_sym == :create
+
+        bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
+        base.option "--managed", "MANAGED", " ", bme_options
+        bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
+        base.option "--build", "BUILD", " ", bme_options
+        bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
+        base.option "--enabled", "ENABLED", " ",  bme_options
+        bme_options[:format] = HammerCLI::Options::Normalizers::Bool.new
+        base.option "--overwrite", "OVERWRITE", " ",  bme_options
+
+        base.option "--parameters", "PARAMS", _("Host parameters."),
+          :format => HammerCLI::Options::Normalizers::KeyValueList.new
+        base.option "--compute-attributes", "COMPUTE_ATTRS", _("Compute resource attributes."),
+          :format => HammerCLI::Options::Normalizers::KeyValueList.new
+        base.option "--volume", "VOLUME", _("Volume parameters"), :multivalued => true,
+          :format => HammerCLI::Options::Normalizers::KeyValueList.new
+        base.option "--interface", "INTERFACE", _("Interface parameters."), :multivalued => true,
+          :format => HammerCLI::Options::Normalizers::KeyValueList.new
+        base.option "--provision-method", "METHOD", " ",
+          :format => HammerCLI::Options::Normalizers::Enum.new(['build', 'image'])
+
+        base.build_options :without => [
+              # - temporarily disabled params that will be removed from the api ------------------
+              :provision_method, :capabilities, :flavour_ref, :image_ref, :start,
+              :network, :cpus, :memory, :provider, :type, :tenant_id, :image_id,
+              # ----------------------------------------------------------------------------------
+              :puppet_class_ids, :host_parameters_attributes, :interfaces_attributes]
+      end
+
+      def self.ask_password
+        prompt = _("Enter the root password for the host:") + " "
+        ask(prompt) {|q| q.echo = false}
+      end
+
+      def request_params
+        params = super
+
+        owner_id = get_resource_id(HammerCLIForeman.foreman_resource(:users), :required => false, :scoped => true)
+        params['host']['owner_id'] ||= owner_id unless owner_id.nil?
+
+        puppet_proxy_id = proxy_id(option_puppet_proxy)
+        params['host']['puppet_proxy_id'] ||= puppet_proxy_id unless puppet_proxy_id.nil?
+
+        puppet_ca_proxy_id = proxy_id(option_puppet_ca_proxy)
+        params['host']['puppet_ca_proxy_id'] ||= puppet_ca_proxy_id unless puppet_ca_proxy_id.nil?
+
+        puppetclass_ids = option_puppetclass_ids || puppet_class_ids(option_puppet_classes)
+        params['host']['puppetclass_ids'] = puppetclass_ids unless puppetclass_ids.nil?
+
+        params['host']['build'] = option_build unless option_build.nil?
+        params['host']['managed'] = option_managed unless option_managed.nil?
+        params['host']['enabled'] = option_enabled unless option_enabled.nil?
+        params['host']['overwrite'] = option_overwrite unless option_overwrite.nil?
+
+        params['host']['host_parameters_attributes'] = parameter_attributes
+        params['host']['compute_attributes'] = option_compute_attributes || {}
+        params['host']['compute_attributes']['volumes_attributes'] = nested_attributes(option_volume_list)
+        params['host']['interfaces_attributes'] = interfaces_attributes
+
+        params['host']['root_pass'] = option_root_password unless option_root_password.nil?
+
+        if option_ask_root_password
+          params['host']['root_pass'] = HammerCLIForeman::Hosts::CommonUpdateOptions::ask_password
+        end
+
+        params
+      end
+
+      private
+
+      def proxy_id(name)
+        resolver.smart_proxy_id('option_name' => name) if name
+      end
+
+      def puppet_class_ids(names)
+        resolver.puppetclass_ids('option_names' => names) if names
+      end
+
+      def parameter_attributes
+        return {} unless option_parameters
+        option_parameters.collect do |key, value|
+          if value.is_a? String
+            {"name"=>key, "value"=>value}
+          else
+            {"name"=>key, "value"=>value.inspect}
+          end
+        end
+      end
+
+      def nested_attributes(attrs)
+        return {} unless attrs
+
+        nested_hash = {}
+        attrs.each_with_index do |attr, i|
+          nested_hash[i.to_s] = attr
+        end
+        nested_hash
+      end
+
+      def interfaces_attributes
+        return {} if option_interface_list.empty?
+
+        # move each attribute starting with "compute_" to compute_attributes
+        option_interface_list.collect do |nic|
+          compute_attributes = {}
+          nic.keys.each do |key|
+            if key.start_with? 'compute_'
+              compute_attributes[key.gsub('compute_', '')] = nic.delete(key)
+            end
+          end
+          nic['compute_attributes'] = compute_attributes unless compute_attributes.empty?
+          nic
+        end
+      end
+    end
+  end
+end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -191,7 +191,7 @@ describe HammerCLIForeman::Host do
     let(:cmd) { HammerCLIForeman::Host::CreateCommand.new("", ctx) }
 
     before :each do
-      HammerCLIForeman::CommonHostUpdateOptions.stubs(:ask_password).returns("password")
+      HammerCLIForeman::Hosts::CommonUpdateOptions.stubs(:ask_password).returns("password")
     end
 
     context "parameters" do
@@ -244,7 +244,7 @@ describe HammerCLIForeman::Host do
     let(:cmd) { HammerCLIForeman::Host::UpdateCommand.new("", ctx) }
 
     before :each do
-      HammerCLIForeman::CommonHostUpdateOptions.stubs(:ask_password).returns("password")
+      HammerCLIForeman::Hosts::CommonUpdateOptions.stubs(:ask_password).returns("password")
     end
 
     context "parameters" do


### PR DESCRIPTION
Requires https://github.com/theforeman/hammer-cli/pull/222
- host create and update commands provide interface for adding compute resource specific information into help
- new module `ComputeResources` for compute resource specific behaviour, the file structure counts with adding more extension types in future (http://projects.theforeman.org/issues/4593, http://projects.theforeman.org/issues/10311, http://projects.theforeman.org/issues/3651, ...)
- host extension modules moved to module `Hosts`
