### PR TITLE
Fixes #16775 - timeout deprecation warning

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -30,7 +30,9 @@ module HammerCLIForeman
     config[:headers] = { "Accept-Language" => HammerCLI::I18n.locale }
     config[:language] = HammerCLI::I18n.locale
     config[:timeout] = HammerCLI::Settings.get(:foreman, :request_timeout)
-    config[:timeout] = -1 if (config[:timeout] && config[:timeout].to_i < 0)
+    if (config[:timeout] && config[:timeout].to_i < 0)
+      config[:timeout] = (RestClient.version < '2.0.0') ? -1 : nil
+    end
     config[:apidoc_authenticated] = false
     config
   end


### PR DESCRIPTION
`nil` is required since rest-client 2.0.0 https://github.com/rest-client/rest-client/commit/4932e7e35807f98ca131412e4b74a9013b3b2dde
