### PR TITLE
The 'start' key always needs a 1 or 0

### DIFF
--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -233,7 +233,7 @@ path                 # path to folder
 guest_id             # guest OS id form VMware
 scsi_controller_type # id of the controller from VMware
 hardware_version     # hardware version id from VMware
-start                # Must be a 1 or 0, whether to start the machine or not
+start                # Boolean, expressed as 0 or 1, whether to start the machine or not
 ```
 
 Available keys for `--interface`:

--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -164,7 +164,7 @@ Available keys for `--compute-attributes`:
 ```
 cpus          # number of CPUs
 memory        # string, amount of memory, value in bytes
-start         # boolean, whether to start the machine or not
+start         # Must be a 1 or 0, whether to start the machine or not
 ```
 
 Available keys for `--interface`:
@@ -198,7 +198,7 @@ cluster
 template   # hardware profile to use
 cores      # int value, number of cores
 memory     # amount of memory, int value in bytes
-start      # boolean, whether to start the machine or not
+start      # Must be a 1 or 0, whether to start the machine or not
 ```
 
 Available keys for `--interface`:

--- a/lib/hammer_cli_foreman/compute_resources/libvirt/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/libvirt/host_help_extenstion.rb
@@ -11,7 +11,7 @@ module HammerCLIForeman
             h.list([
               ['cpus',   _('Number of CPUs')],
               ['memory', _('String, amount of memory, value in bytes')],
-              ['start',  _('Boolean, whether to start the machine or not')]
+              ['start',  _('Boolean (expressed as 0 or 1), whether to start the machine or not')]
             ])
           end
           h.section '--interface' do |h|

--- a/lib/hammer_cli_foreman/compute_resources/ovirt/host_help_extenstion.rb
+++ b/lib/hammer_cli_foreman/compute_resources/ovirt/host_help_extenstion.rb
@@ -13,7 +13,7 @@ module HammerCLIForeman
               ['template', _('Hardware profile to use')],
               ['cores',    _('Integer value, number of cores')],
               ['memory',   _('Amount of memory, integer value in bytes')],
-              ['start',    _('Boolean, whether to start the machine or not')]
+              ['start',    _('Boolean (expressed as 0 or 1), whether to start the machine or not')]
             ])
           end
           h.section '--interface' do |h|


### PR DESCRIPTION
Previously, the docs mentioned that the 'start' key for compute-attributes is
a boolean. This suggests values like 'true', 'false', 'yes' and 'no' would be
accepted.

This was not the case. For libvirt (which is what I tested with, I assume oVirt
is the same), a 'true' or 'false' value did nothing, only a 1 or 0 did.

This patch fixes the docs to explain a 0 or 1 is required to influence
autostart behaviour.