### PR TITLE
Fixes #17730 - prevent from setting taxonomies for non-overriding filters

### DIFF
--- a/lib/hammer_cli_foreman/filter.rb
+++ b/lib/hammer_cli_foreman/filter.rb
@@ -58,7 +58,7 @@ module HammerCLIForeman
             org_opts = '--organization[s|-ids]'
             loc_opts = '--location[s|-ids]'
 
-            h.text(_("Filters inherrit organizations and locations from it's role by default. This behavior can be changed by setting %{condition}\n"+
+            h.text(_("Filters inherit organizations and locations from its role by default. This behavior can be changed by setting %{condition}\n"+
               "Therefore options %{org_opts} and %{loc_opts} are applicable only when the override flag is set.") % {
               :org_opts => org_opts,
               :loc_opts => loc_opts,

--- a/test/unit/filter_test.rb
+++ b/test/unit/filter_test.rb
@@ -58,8 +58,12 @@ describe HammerCLIForeman::Filter do
   end
 
   context "CreateCommand" do
-
     let(:cmd) { HammerCLIForeman::Filter::CreateCommand.new("", ctx) }
+
+    before do
+      # FIXME: remove stubbing option_override once tests are switched to apidoc 1.14+
+      cmd.stubs(:option_override).returns(false)
+    end
 
     context "parameters" do
       it_should_accept "role id and permission ids", ["--role-id=1", "--permission-ids=1,2"]
@@ -79,8 +83,12 @@ describe HammerCLIForeman::Filter do
   end
 
   context "UpdateCommand" do
-
     let(:cmd) { HammerCLIForeman::Filter::UpdateCommand.new("", ctx) }
+
+    before do
+      # FIXME: remove stubbing option_override once tests are switched to apidoc 1.14+
+      cmd.stubs(:option_override).returns(false)
+    end
 
     context "parameters" do
       it_should_accept "id, role id and permission ids", ["--id=1", "--role-id=1", "--permission-ids=1,2"]


### PR DESCRIPTION
* signals usage error when org/loc options are used and --override is
  false
* resets taxonomies when filter's override flag is modified to false
* extends help with usage description