### PR TITLE
Fixes #17936 - default org/loc work with authenticators

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,7 @@ look at [the development documentation](doc/developer_docs.md#hammer-development
 
 How to test
 ------------
-
-```bash
-   $ bundle install
-   $ bundle exec "rake test"
-```
-
-Generated coverage reports are stored in ./coverage directory.
-
-There is support for testing against API documentation (and sample data) generated from different versions of Foreman.
-The required version of Foreman can be set in env variable `TEST_API_VERSION`. Make sure the requested data are
-in `test/unit/data/<version>/`.
-
-```bash
-  $ TEST_API_VERSION=1.10 bundle exec rake test
-```
+Please read our [testing documentation](doc/testing.md#testing-hammer-commands) for more information about how to write and run tests.
 
 
 License

--- a/doc/developer_docs.md
+++ b/doc/developer_docs.md
@@ -6,9 +6,10 @@ There's a lot of useful information in
 Studying it first can help you to understand the basic principles.
 
 Foreman plugin extends the Hammer Core in following areas:
- - [Using HammerCLIForeman::Command](using_hammer_cli_foreman_command.md)
- - [Building options](option_builder.md#option-builder)
- - [Automatic name resolution](name_id_resolution.md#name---id-resolution)
+ - [Using HammerCLIForeman::Command](using_hammer_cli_foreman_command.md#using-hammercliforeman)
+ - [Building options](option_builder.md#option-builders)
+ - [Automatic name resolution](name_id_resolution.md#name-to-id-resolution)
+ - [Testing commands](testing.md#testing-hammer-commands)
 
 It's recommended that you set `:refresh_cache: true` in the plugin settings if
 engaging in API development to enable aggressive apidoc cache checking.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,133 @@
+# Testing hammer commands
+
+Commands from `hammer-cli-foreman` are tested by two types of tests:
+- *unit tests* - They're placed in `test/unit` and test only basic functionality of the commands like accepted options and field labels printed to stdout. Unit tests for commands are no longer extended.
+- *functional tests* - They're placed in `test/functional` and aim to test commands in broader context. Functional tests require mocking the api calls and should also test output based on data returned from the api. This is preferable way of testing the commands.
+
+
+## Running the tests
+
+```bash
+bundle install
+bundle exec rake test
+```
+
+Generated coverage reports are stored in ./coverage directory.
+
+There is support for testing against API documentation generated from different versions of Foreman.
+The required version of Foreman can be set in env variable `TEST_API_VERSION`. Make sure the requested data are in `test/unit/data/<version>/`.
+```bash
+$ TEST_API_VERSION=1.13 bundle exec rake test
+```
+
+## Testing API expectations
+
+`hammer-cli-foreman` comes with a set of helpers and extensions to [Mocha](https://github.com/freerange/mocha) library for easier testing and better error detection.
+
+The extensions are included in `test/test_helper.rb` by default. It's also possible to include it elswhere when needed:
+```ruby
+require 'hammer_cli_foreman/testing/api_expectations'
+include HammerCLIForeman::Testing::APIExpectations
+```
+
+### Available helper functions
+
+**`api_expects`**`(resource=nil, action=nil, note=nil, &block)`
+* `resource` Symbol with plural name of the resource.
+* `action` Symbol with action name.
+* `note` String with description of the expected call to make its identification easier when the expectation fails.
+* `&block` Optional block for testing parameters.
+
+ `api_expects` is often used together with `with_params` that set expectation on parameters that need to be included in the call:
+```ruby
+describe 'hostgroup create' do
+  it 'passes architecture id' do
+    api_expects(:hostgroups, :create, 'Create hostgroup with architecture_id').with_params('hostgroup' => {
+      'name' => 'hg1',
+      'architecture_id' => 1
+    })
+
+    run_cmd(%w(hostgroup create --name hg1 --architecture-id 1))
+  end
+end
+```
+
+The expectation failure is reported with description of the call and expected parameters to make searching for mistakes easier:
+```
+unexpected invocation: #<AnyInstance:ApipieBindings::API>.call_action(<Action hostgroups:create>, {'hostgroup' => {'name' => 'hg1', 'architecture_id' => 2}}, {}, {:fake_response => nil})
+unsatisfied expectations:
+- expected exactly once, not yet invoked: Create hostgroup with architecture_id
+  #<AnyInstance:ApipieBindings::API>.call_action(:hostgroups, :create, *any_argument)
+  expected params to include: {
+    "hostgroup": {
+      "name": "hg1",
+      "architecture_id": 1
+    }
+  }
+```
+
+Alternatively parameters can be tested in a block:
+```ruby
+describe 'hostgroup create' do
+  it 'passes architecture id' do
+    api_expects(:hostgroups, :create, 'Create hostgroup with architecture_id') do |p|
+      p['hostgroup']['architecture_id'] == 1 && p['hostgroup']['name'] == 'hg1'
+    end
+
+    run_cmd(%w(hostgroup create --name hg1 --architecture-id 1))
+  end
+end
+```
+
+This approach gives more freedom in what is tested and how but can't report what parameters were expected in case of failure.
+
+**`api_expects_no_call`**
+
+Makes sure no API call is performed.
+
+Example:
+```ruby
+describe 'hostgroup create' do
+  it "doesn't perform any api request when name is missing" do
+    api_expects_no_call
+    run_cmd(%w(hostgroup create))
+  end
+end
+```
+
+**`api_expects_search`**`(resource=nil, search_options={}, note=nil)`
+* `resource` Symbol with plural name of the resource.
+* `search_options` Either hash with options to search by (eg. `:name => 'x86_64'`) or a string with the search query.
+* `note` String with description of the expected call to make its identification easier when the expectation fails.
+
+Helper that sets expectation on searching for a resource when hammer translates from name of the resource to its id. It's often used together with `returns` that mocks result of the search query.
+
+Example:
+```ruby
+describe 'hostgroup create' do
+  let(:arch) {{'id' => 1, 'name' => 'arch1'}}
+
+  it 'resolves architecture name' do
+    api_expects_search(:architectures, { :name => 'arch1' }).returns(index_response([arch]))
+    run_cmd(%w(hostgroup create --name hg1 --architecture arch1))
+  end
+end
+```
+
+**`api_connection`**`(options={}, version = '1.15')`
+* `options` Hash with options for the api connection.
+* `version` Version of the Foreman apidoc. Available exported versions are located in subdirectories of `test/data/`.
+
+The function returns instance of `FakeApiConnection` that makes `#authenticator` public and allows setting expectations on it. Useful for injection of api instances into tested objects.
+
+**`APIExpectationsDecorator`**
+
+Decorator class that adds helpers for setting expectations on the wrapped api instance.
+Provides methods `expects_call`, `expects_no_call` and `expects_search` that behave similarly to the helpers described above.
+
+Example usage:
+```ruby
+connection = api_connection
+api = APIExpectationsDecorator.new(connection.api)
+api.expects_search(:users, 'login=admin')
+```

--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -18,8 +18,6 @@ module HammerCLIForeman
   require 'hammer_cli_foreman/param_filters'
   require 'hammer_cli_foreman/id_resolver'
   require 'hammer_cli_foreman/dependency_resolver'
-  require 'hammer_cli_foreman/defaults'
-
 
   begin
     require 'hammer_cli_foreman/commands'
@@ -27,6 +25,7 @@ module HammerCLIForeman
     require 'hammer_cli_foreman/references'
     require 'hammer_cli_foreman/parameter'
     require 'hammer_cli_foreman/common_parameter'
+    require 'hammer_cli_foreman/defaults'
 
     HammerCLI::MainCommand.lazy_subcommand('auth', _("Foreman connection login/logout."),
       'HammerCLIForeman::Auth', 'hammer_cli_foreman/auth'

--- a/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
+++ b/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
@@ -63,6 +63,10 @@ module HammerCLIForeman
         @authenticator.response(r)
       end
 
+      def user
+        @authenticator.user if @authenticator.respond_to?(:user)
+      end
+
       protected
 
       def session_storage

--- a/lib/hammer_cli_foreman/defaults.rb
+++ b/lib/hammer_cli_foreman/defaults.rb
@@ -1,7 +1,8 @@
 require 'hammer_cli'
 module HammerCLIForeman
   class Defaults < HammerCLI::BaseDefaultsProvider
-    def initialize
+    def initialize(api_connection = HammerCLIForeman.foreman_api_connection)
+      @api_connection = api_connection
       @provider_name = 'foreman'
       @supported_defaults = [:organization_id, :location_id]
       @description = _('Use the default organization and/or location from the server')
@@ -21,9 +22,11 @@ module HammerCLIForeman
 
     private
     def get_user
-      HammerCLIForeman.foreman_resource(:users).action(:index).call(:search =>"login="+HammerCLIForeman.credentials.username)
+      login = @api_connection.authenticator.user
+      users = @api_connection.resource(:users).action(:index).call(:search => "login=#{login}")
+      users
     end
   end
-  HammerCLI.defaults.register_provider(Defaults.new())
 
+  HammerCLI.defaults.register_provider(Defaults.new)
 end

--- a/test/functional/test_helper.rb
+++ b/test/functional/test_helper.rb
@@ -3,8 +3,5 @@ require File.join(File.dirname(__FILE__), '../test_helper')
 require 'hammer_cli/testing/command_assertions'
 require 'hammer_cli/testing/output_matchers'
 
-require 'hammer_cli_foreman/testing/api_expectations'
-
 include HammerCLI::Testing::CommandAssertions
 include HammerCLI::Testing::OutputMatchers
-include HammerCLIForeman::Testing::APIExpectations

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,15 +15,13 @@ require "minitest-spec-context"
 require "mocha/setup"
 
 require 'hammer_cli'
+require 'hammer_cli_foreman/testing/api_expectations'
 
 FOREMAN_VERSION = Gem::Version.new(ENV['TEST_API_VERSION'] || '1.15')
 
+include HammerCLIForeman::Testing::APIExpectations
 HammerCLI.context[:api_connection].create('foreman') do
-  HammerCLI::Apipie::ApiConnection.new({
-    :apidoc_cache_dir => 'test/data/' + FOREMAN_VERSION.to_s,
-    :apidoc_cache_name => 'foreman_api',
-    :dry_run => true
-  })
+  api_connection({}, FOREMAN_VERSION)
 end
 
 require 'hammer_cli_foreman'

--- a/test/unit/api/session_authenticator_wrapper_test.rb
+++ b/test/unit/api/session_authenticator_wrapper_test.rb
@@ -270,4 +270,18 @@ describe HammerCLIForeman::Api::SessionAuthenticatorWrapper do
     end
   end
 
+  describe '#user' do
+    it "returns nil when wrapped authenticator doesn't respond to #user" do
+      prepare_session_storage do |auth, dir|
+        assert_nil auth.user
+      end
+    end
+
+    it "calls #user on the wrapped authentocator" do
+      prepare_session_storage do |auth, dir|
+        wrapped_auth.expects(:user).returns('admin')
+        assert_equal 'admin', auth.user
+      end
+    end
+  end
 end

--- a/test/unit/defaults_test.rb
+++ b/test/unit/defaults_test.rb
@@ -1,32 +1,36 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
+
 describe HammerCLIForeman::Defaults do
+  let(:user) {
+    {"default_organization" => {"id" => 2}, "default_location" => {"id" => 1}}
+  }
+  let(:empty_user) {
+    {"default_organization" => nil, "default_location" => nil}
+  }
 
-  context "Defaults" do
-
-    defaults_provider = HammerCLIForeman::Defaults.new
-    user = {"results" => ["default_organization" => {"id" => 2}, "default_location" => {"id" => 1}]}
-    empty_user = {"results" => ["default_organization" => nil, "default_location" => nil]}
-
-    it "returns defaults organization when exisits " do
-      defaults_provider.stubs(:get_user).returns user
-      assert_equal 2, defaults_provider.get_defaults(:organization_id)
-    end
-
-    it "returns nil when defaults organization doesn't exisits " do
-      defaults_provider.stubs(:get_user).returns empty_user
-      assert_nil defaults_provider.get_defaults(:organization_id)
-    end
-
-    it "returns defaults location when exisits " do
-      defaults_provider.stubs(:get_user).returns user
-      assert_equal 1, defaults_provider.get_defaults(:location_id)
-    end
-
-    it "returns nil when defaults location doesn't exisits " do
-      defaults_provider.stubs(:get_user).returns empty_user
-      assert_nil defaults_provider.get_defaults(:location_id)
-    end
-
+  before do
+    connection = api_connection
+    @api = APIExpectationsDecorator.new(connection.api)
+    @defaults_provider = HammerCLIForeman::Defaults.new(connection)
   end
 
+  it "returns defaults organization when exisits " do
+    @api.expects_search(:users, 'login=admin').returns(index_response([user]))
+    assert_equal 2, @defaults_provider.get_defaults(:organization_id)
+  end
+
+  it "returns nil when defaults organization doesn't exisits " do
+    @api.expects_search(:users, 'login=admin').returns(index_response([empty_user]))
+    assert_nil @defaults_provider.get_defaults(:organization_id)
+  end
+
+  it "returns defaults location when exisits " do
+    @api.expects_search(:users, 'login=admin').returns(index_response([user]))
+    assert_equal 1, @defaults_provider.get_defaults(:location_id)
+  end
+
+  it "returns nil when defaults location doesn't exisits " do
+    @api.expects_search(:users, 'login=admin').returns(index_response([empty_user]))
+    assert_nil @defaults_provider.get_defaults(:location_id)
+  end
 end


### PR DESCRIPTION
Method HammerCLIForeman.credentials was removed with session
authenticators re-work.

**TODO:**
- [x] tests for the issue