### PR TITLE
Fixes #18319 - poweroff hosts when using --force option

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -321,7 +321,7 @@ module HammerCLIForeman
 
       def option_power_action
         if option_force?
-          :cycle
+          :poweroff
         else
           :stop
         end


### PR DESCRIPTION
Tested with 
- vSphere Version 6.0.0 Build 2997665
- RHV 4
- libvirt

RHV4 will do a normal shutdown.