### PR TITLE
Fixes #18739 - Display hostgroup_title on Host actions

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -30,7 +30,7 @@ module HammerCLIForeman
         field :id, _("Id")
         field :name, _("Name")
         field nil, _("Operating System"), Fields::SingleReference, :key => :operatingsystem
-        field :hostgroup_title, _("Host Group")
+        field nil, _("Host Group"), Fields::SingleReference, :key => :hostgroup, :display_field => 'title'
         field :ip, _("IP")
         field :mac, _("MAC")
       end
@@ -64,7 +64,7 @@ module HammerCLIForeman
         field :name, _("Name")
         field nil, _("Organization"), Fields::SingleReference, :key => :organization, :hide_blank => true
         field nil, _("Location"), Fields::SingleReference, :key => :location, :hide_blank => true
-        field :hostgroup_title, _("Host Group")
+        field nil, _("Host Group"), Fields::SingleReference, :key => :hostgroup, :display_field => 'title'
         field nil, _("Compute Resource"), Fields::SingleReference, :key => :compute_resource
         field nil, _("Compute Profile"), Fields::SingleReference, :key => :compute_profile, :hide_blank => true
         field nil, _("Environment"), Fields::SingleReference, :key => :environment

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -30,7 +30,7 @@ module HammerCLIForeman
         field :id, _("Id")
         field :name, _("Name")
         field nil, _("Operating System"), Fields::SingleReference, :key => :operatingsystem
-        field nil, _("Host Group"), Fields::SingleReference, :key => :hostgroup
+        field :hostgroup_title, _("Host Group")
         field :ip, _("IP")
         field :mac, _("MAC")
       end
@@ -64,7 +64,7 @@ module HammerCLIForeman
         field :name, _("Name")
         field nil, _("Organization"), Fields::SingleReference, :key => :organization, :hide_blank => true
         field nil, _("Location"), Fields::SingleReference, :key => :location, :hide_blank => true
-        field nil, _("Host Group"), Fields::SingleReference, :key => :hostgroup
+        field :hostgroup_title, _("Host Group")
         field nil, _("Compute Resource"), Fields::SingleReference, :key => :compute_resource
         field nil, _("Compute Profile"), Fields::SingleReference, :key => :compute_profile, :hide_blank => true
         field nil, _("Environment"), Fields::SingleReference, :key => :environment

--- a/lib/hammer_cli_foreman/output/fields.rb
+++ b/lib/hammer_cli_foreman/output/fields.rb
@@ -6,9 +6,10 @@ module Fields
 
     def display?(value)
       id_key = "#{parameters[:key]}_id"
-      name_key = "#{parameters[:key]}_name"
+      display_field = parameters[:display_field] || 'name'
+      display_key = "#{parameters[:key]}_#{display_field}"
 
-      (value[name_key.to_sym] || value[name_key]) && (value[id_key.to_sym] || value[id_key])
+      (value[display_key.to_sym] || value[display_key]) && (value[id_key.to_sym] || value[id_key])
     end
   end
 

--- a/lib/hammer_cli_foreman/output/formatters.rb
+++ b/lib/hammer_cli_foreman/output/formatters.rb
@@ -11,11 +11,12 @@ module HammerCLIForeman::Output
         return "" if resource.nil?
 
         key = field_params[:key]
+        display_field = field_params[:display_field] || 'name'
 
         id_key = "#{key}_id"
-        name_key = "#{key}_name"
+        display_key = "#{key}_#{display_field}"
 
-        name = resource[name_key.to_sym] || resource[name_key]
+        name = resource[display_key.to_sym] || resource[display_key]
         id = resource[id_key.to_sym] || resource[id_key]
 
         context = field_params[:context] || {}

--- a/lib/hammer_cli_foreman/references.rb
+++ b/lib/hammer_cli_foreman/references.rb
@@ -99,7 +99,7 @@ module HammerCLIForeman
     def self.hostgroups(dsl)
       dsl.build do
         collection :hostgroups, _("Hostgroups"), :numbered => false do
-          custom_field Fields::Reference
+          custom_field Fields::Reference, :name_key => :title
         end
       end
     end


### PR DESCRIPTION
Before this patch, host list was displaying only the leaf of the
hostgroup tree. E.g:

base/hostgroup1

displayed as 'hostgroup1' in the Host list table.

After this patch, 'base/hostgroup1' is displayed, which is more useful
than the leaf (which could be the same for different trees). The same
thing has been fixed for Host info.

@tstrachota I also wonder if we should do this for organizations/locations