### PR TITLE
Fixes #18663 - Fix added with set and delete parameters

### DIFF
--- a/lib/hammer_cli_foreman/subnet.rb
+++ b/lib/hammer_cli_foreman/subnet.rb
@@ -44,7 +44,7 @@ module HammerCLIForeman
       success_message _("Subnet created")
       failure_message _("Could not create the subnet")
 
-      build_options
+      build_options :without => [:subnet_parameters_attributes]
     end
 
 
@@ -53,7 +53,7 @@ module HammerCLIForeman
       success_message _("Subnet updated")
       failure_message _("Could not update the subnet")
 
-      build_options
+      build_options :without => [:subnet_parameters_attributes]
     end
 
 
@@ -61,6 +61,34 @@ module HammerCLIForeman
 
       success_message _("Subnet deleted")
       failure_message _("Could not delete the subnet")
+
+      build_options :without => [:subnet_parameters_attributes]
+    end
+
+    class SetParameterCommand < HammerCLIForeman::Parameter::SetCommand
+      desc _("Create or update parameter for a subnet.")
+
+      success_message_for :update, _("Subnet parameter updated")
+      success_message_for :create, _("New subnet parameter created")
+      failure_message _("Could not set subnet parameter")
+
+      def validate_options
+        super
+        validator.any(:option_subnet_name, :option_subnet_id).required
+      end
+
+      build_options
+    end
+
+    class DeleteParameterCommand < HammerCLIForeman::Parameter::DeleteCommand
+      desc _("Delete parameter for a subnet.")
+
+      success_message _("Subnet parameter deleted")
+
+      def validate_options
+        super
+        validator.any(:option_subnet_name, :option_subnet_id).required
+      end
 
       build_options
     end


### PR DESCRIPTION
`--subnet-parameters-attributes` was removed and replaced by -
`hammer subnet set-parameter` and  `hammer subnet delete-parameter`