### PR TITLE
Fixes #19362 - custom error for 401 unauthorized

### DIFF
--- a/lib/hammer_cli_foreman/api.rb
+++ b/lib/hammer_cli_foreman/api.rb
@@ -1,3 +1,9 @@
 require 'hammer_cli_foreman/api/connection'
 
+module HammerCLIForeman
+  module Api
+    class UnauthorizedError < RuntimeError; end
+  end
+end
+
 HammerCLIForeman.init_api_connection

--- a/lib/hammer_cli_foreman/api/interactive_basic_auth.rb
+++ b/lib/hammer_cli_foreman/api/interactive_basic_auth.rb
@@ -12,7 +12,7 @@ module HammerCLIForeman
       end
 
       def error(ex)
-        ex.message = _("Invalid username or password") if ex.is_a?(RestClient::Unauthorized)
+        return UnauthorizedError.new(_("Invalid username or password")) if ex.is_a?(RestClient::Unauthorized)
       end
 
       def status

--- a/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
+++ b/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
@@ -48,9 +48,9 @@ module HammerCLIForeman
         load_session
         if ex.is_a?(RestClient::Unauthorized) && !@session_id.nil?
           destroy_session
-          ex.message = _("Session has expired")
+          return UnauthorizedError.new(_("Session has expired"))
         else
-          @authenticator.error(ex)
+          return @authenticator.error(ex)
         end
       end
 

--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -11,11 +11,18 @@ module HammerCLIForeman
         [RestClient::Forbidden, :handle_forbidden],
         [RestClient::UnprocessableEntity, :handle_unprocessable_entity],
         [RestClient::MovedPermanently, :handle_moved_permanently],
+        [HammerCLIForeman::Api::UnauthorizedError, :handle_foreman_unauthorized],
         [ArgumentError, :handle_argument_error],
       ]
     end
 
     protected
+
+    def handle_foreman_unauthorized(e)
+      print_error e.message
+      log_full_error e
+      HammerCLI::EX_UNAUTHORIZED
+    end
 
     def handle_unprocessable_entity(e)
       response = JSON.parse(e.response)

--- a/test/unit/api/interactive_basic_auth_test.rb
+++ b/test/unit/api/interactive_basic_auth_test.rb
@@ -69,18 +69,18 @@ describe HammerCLIForeman::Api::InteractiveBasicAuth do
   describe '#error' do
     let(:auth) { HammerCLIForeman::Api::InteractiveBasicAuth.new(nil, nil) }
 
-    it 'overrides exception message for unauthorized exception' do
+    it 'overrides unauthorized exception' do
       ex = RestClient::Unauthorized.new
-      auth.error(ex)
+      new_ex = auth.error(ex)
 
-      assert_equal 'Invalid username or password', ex.message
+      assert_equal 'Invalid username or password', new_ex.message
     end
 
-    it 'keeps the message for other exceptions' do
+    it 'does not override other exceptions' do
       ex = RuntimeError.new('Some error')
-      auth.error(ex)
+      new_ex = auth.error(ex)
 
-      assert_equal 'Some error', ex.message
+      assert_nil new_ex
     end
   end
 end

--- a/test/unit/api/session_authenticator_wrapper_test.rb
+++ b/test/unit/api/session_authenticator_wrapper_test.rb
@@ -166,26 +166,26 @@ describe HammerCLIForeman::Api::SessionAuthenticatorWrapper do
         end
       end
 
-      it 'overrides 401 error message' do
+      it 'overrides 401 exception' do
         prepare_session_storage :session_id => 'SOME_SESSION_ID' do |auth, dir|
           ex = RestClient::Unauthorized.new
-          auth.error(ex)
+          new_ex = auth.error(ex)
 
-          assert_equal 'Session has expired', ex.message
+          assert_equal 'Session has expired', new_ex.message
         end
       end
 
-      it 'keeps error message for other exceptions' do
+      it 'does not override other exceptions' do
         prepare_session_storage :session_id => 'SOME_SESSION_ID' do |auth, dir|
           ex = RuntimeError.new('Some error')
           wrapped_auth.expects(:error).with(ex)
-          auth.error(ex)
+          new_ex = auth.error(ex)
 
-          assert_equal 'Some error', ex.message
+          assert_nil new_ex
         end
       end
 
-      it 'keeps sessione for other exceptions' do
+      it 'keeps session for other exceptions' do
         prepare_session_storage :session_id => 'SOME_SESSION_ID' do |auth, dir|
           ex = RuntimeError.new('Some error')
           wrapped_auth.expects(:error).with(ex)


### PR DESCRIPTION
Previous solution modified message of the original `RestClient::Unauthorized`. Unfortunatly this attribute isn't writable in all RestClient versions.

Requires: https://github.com/Apipie/apipie-bindings/pull/64