### PR TITLE
Fixes #19358 - require rest-client >= 1.8.0

### DIFF
--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -27,5 +27,6 @@ EOF
 
   s.add_dependency 'hammer_cli', '>= 0.10.0'
   s.add_dependency 'apipie-bindings', '>= 0.0.19'
+  s.add_dependency 'rest-client', '>= 1.8.0', '< 3.0.0'
 
 end


### PR DESCRIPTION
rest-client < 1.8.0 lack support for sessions