### PR TITLE
Refs #19390 - More detailed instructions on SSL verification fail

### DIFF
--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -93,6 +93,7 @@ module HammerCLIForeman
     def ssl_cert_instructions
       host_url = HammerCLI::Settings.get(:_params, :host) || HammerCLI::Settings.get(:foreman, :host)
       uri = URI.parse(host_url)
+      ssl_option = HammerCLI::SSLOptions.new.get_options(uri)
       if uri.host.nil?
         host = '<FOREMAN_HOST>'
         cert_name = "#{host}.crt"
@@ -103,11 +104,20 @@ module HammerCLIForeman
 
       cmd = "hammer --fetch-ca-cert #{host}"
 
-      _("Make sure you configured the correct URL and have the server's CA certificate installed on your system.") + "\n\n" +
-      _("You can use hammer to fetch the CA certificate from the server. Be aware that hammer cannot verify whether the certificate is correct and you should verify its authenticity after downloading it.") +
-      "\n\n" +
-      _("Download the certificate as follows:") +
-      "\n\n  $ #{cmd}\n\n"
+      if !ssl_option[:ssl_ca_path].nil? || !ssl_option[:ssl_ca_file].nil?
+        instructions = _("The following configuration option were used for the SSL connection:" ) + "\n"
+        instructions << "  ssl_ca_path = #{ssl_option[:ssl_ca_path]}\n" unless ssl_option[:ssl_ca_path].nil?
+        instructions << "  ssl_ca_file = #{ssl_option[:ssl_ca_file]}\n" unless ssl_option[:ssl_ca_file].nil?
+        instructions << "\n" + _("Make sure the location contain valid CA certificate for #{host_url}")
+      else
+        instructions = _("You can use hammer to fetch the CA certificate from the server. Be aware that hammer cannot verify whether the certificate is correct and you should verify its authenticity after downloading it.") +
+            "\n\n" +
+            _("Download the certificate as follows:") +
+            "\n\n  $ #{cmd}\n\n"
+      end
+
+      _("Make sure you configured the correct URL and have the server's CA certificate installed on your system.") +
+          "\n\n" + instructions
     end
 
     def rake_command

--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -108,12 +108,11 @@ module HammerCLIForeman
         instructions = _("The following configuration option were used for the SSL connection:" ) + "\n"
         instructions << "  ssl_ca_path = #{ssl_option[:ssl_ca_path]}\n" unless ssl_option[:ssl_ca_path].nil?
         instructions << "  ssl_ca_file = #{ssl_option[:ssl_ca_file]}\n" unless ssl_option[:ssl_ca_file].nil?
-        instructions << "\n" + _("Make sure the location contain valid CA certificate for #{host_url}")
+        instructions << "\n" + _("Make sure the location contains an unexpired and valid CA certificate for #{host_url}")
       else
-        instructions = _("You can use hammer to fetch the CA certificate from the server. Be aware that hammer cannot verify whether the certificate is correct and you should verify its authenticity after downloading it.") +
-            "\n\n" +
-            _("Download the certificate as follows:") +
-            "\n\n  $ #{cmd}\n\n"
+        instructions = _("You can use hammer to fetch the CA certificate from the server. Be aware that hammer cannot verify whether the certificate is correct and you should verify its authenticity after downloading it.")
+        instructions << "\n\n" + _("Download the certificate as follows:")
+        instructions << "\n\n  $ #{cmd}\n\n"
       end
 
       _("Make sure you configured the correct URL and have the server's CA certificate installed on your system.") +


### PR DESCRIPTION
We can assume the user already downloaded the CA cert If `ssl_ca_path` or =`ssl_ca_file` options were used and can give better instructions for that case:
```
$ hammer -s https://sat.lab.eng.bos.redhat.com --ssl-ca-file non_ca_cert.pem user list 
SSL certificate verification failed
Make sure you configured the correct URL and have the server's CA certificate installed on your system.

The following configuration option were used for the SSL connection:
  ssl_ca_file = non_ca_cert.pem

Make sure the location contain valid CA certificate for https://sat.lab.eng.bos.redhat.com
```