### PR TITLE
Fixes #20709 - Owner Name is shown in hammer host info command

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -113,7 +113,7 @@ module HammerCLIForeman
 
         # additional info
         label _("Additional info") do
-          field :owner_id, _("Owner Id")
+          field nil, _("Owner"), Fields::SingleReference, :key => :owner
           field :owner_type, _("Owner Type")
           field :enabled, _("Enabled"), Fields::Boolean
           field nil, _("Model"), Fields::SingleReference, :key => :model, :hide_blank => true


### PR DESCRIPTION
`hammer host info` command previously shows just the User ID. With this change, user name is displayed in the Additional info section of `hammer host info` command.

This PR depends on https://github.com/theforeman/foreman/pull/4742. 