### PR TITLE
Fixes #20712 - REX option would be show if its enabled on interface

### DIFF
--- a/lib/hammer_cli_foreman/interface.rb
+++ b/lib/hammer_cli_foreman/interface.rb
@@ -9,6 +9,7 @@ module HammerCLIForeman
       flags = []
       flags << _('primary') if nic['primary']
       flags << _('provision') if nic['provision']
+      flags << _('execution') if nic['execution']
 
       type = nic['type']
       if !flags.empty?
@@ -51,6 +52,7 @@ module HammerCLIForeman
         field :managed, _("Managed"), Fields::Boolean
         field :primary, _("Primary"), Fields::Boolean
         field :provision, _("Provision"), Fields::Boolean
+        field :execution, _("Remote Execution"), Fields::Boolean
         field :virtual, _("Virtual"), Fields::Boolean
         field :tag, _("Tag"), nil, :hide_blank => true
         field :attached_to, _("Attached to"), nil, :hide_blank => true


### PR DESCRIPTION
REX option would show for the interface if its enabled. See below 

~~~
hammer host info --id 8
Id:                       8
Name:                     rhel70.lab.example.com
Organization:             Default Organization
Location:                 Default Location
Puppet CA Id:             
Puppet Master Id:         
Cert name:                rhel70.lab.example.com
Managed:                  no
Installed at:             
Last report:              
Network:                  
    IP:  192.168.121.166
    MAC: 52:54:00:62:a3:74
Network interfaces:       
 1) Id:          10
    Identifier:  eth0
    Type:        interface (primary, provision, execution)    -----> execution option is shown 
    MAC address: 52:54:00:62:a3:74
    IP address:  192.168.121.166
    FQDN:        rhel70.lab.example.com
~~~