### PR TITLE
Fixes #20758 - Show empty table field with ReferenceFormatter

### DIFF
--- a/lib/hammer_cli_foreman/output/formatters.rb
+++ b/lib/hammer_cli_foreman/output/formatters.rb
@@ -35,7 +35,7 @@ module HammerCLIForeman::Output
       end
 
       def format(reference, field_params={})
-        return "" if reference.nil?
+        return "" if reference.nil? || reference == ""
 
         id_key = field_params[:id_key] || :id
         name_key = field_params[:name_key] || :name

--- a/test/unit/output/formatters_test.rb
+++ b/test/unit/output/formatters_test.rb
@@ -100,6 +100,10 @@ describe HammerCLIForeman::Output::Formatters::ReferenceFormatter do
       options = {:context => {:show_ids => true}, :details => [:url, :desc]}
       formatter.format(reference_sym_keys, options).must_equal 'Server (URL, Description, id: 1)'
     end
+
+    it "handles empty string properly" do
+      formatter.format("", {}).must_equal ""
+    end
   end
 
   context "with string keys" do


### PR DESCRIPTION
When [data_for_field](https://github.com/theforeman/hammer-cli/blob/master/lib/hammer_cli/output/adapter/table.rb#L78) are `nil`, empty string is passed to [format](https://github.com/theforeman/hammer-cli-foreman/blob/master/lib/hammer_cli_foreman/output/formatters.rb#L37) 