### PR TITLE
Fixes #20476 - Add ssh-keys commands

### DIFF
--- a/lib/hammer_cli_foreman/ssh_keys.rb
+++ b/lib/hammer_cli_foreman/ssh_keys.rb
@@ -1,0 +1,47 @@
+module HammerCLIForeman
+  class SSHKeys < HammerCLIForeman::Command
+    resource :ssh_keys
+    command_name "ssh-keys"
+    desc _("Manage SSH Keys sources.")
+
+    class ListCommand < HammerCLIForeman::ListCommand
+      output do
+        field :id, _("Id")
+        field :name, _("Name")
+        field :fingerprint, _("Fingerprint")
+        field :length, _("Length")
+        field :created_at, _("Created at"), Fields::Date
+      end
+
+      build_options
+    end
+
+    class CreateCommand < HammerCLIForeman::CreateCommand
+      command_name "add"
+
+      option "--key-file", "KEY_FILE", _("Path to a SSH public key"),
+             :format => HammerCLI::Options::Normalizers::File.new
+
+      def request_params
+        params = super
+        params['user_id'] ||= params['ssh_key']['user_id']
+        params['ssh_key']['key'] ||= options['option_key_file']
+        params
+      end
+
+      success_message _("SSH Key %{name} added")
+      failure_message _("Could not add SSH Key")
+
+      build_options
+    end
+
+    class DeleteCommand < HammerCLIForeman::DeleteCommand
+      success_message _("SSH Key deleted")
+      failure_message _("Could not delete the SSH Key")
+
+      build_options
+    end
+
+    autoload_subcommands
+  end
+end

--- a/lib/hammer_cli_foreman/user.rb
+++ b/lib/hammer_cli_foreman/user.rb
@@ -135,10 +135,10 @@ module HammerCLIForeman
     end
 
     HammerCLIForeman::AssociatingCommands::Role.extend_command(self)
-
+    lazy_subcommand('ssh-keys', _("Managing User SSH Keys."),
+      'HammerCLIForeman::SSHKeys', 'hammer_cli_foreman/ssh_keys'
+    )
     autoload_subcommands
   end
 
 end
-
-

--- a/test/functional/ssh_keys_test.rb
+++ b/test/functional/ssh_keys_test.rb
@@ -1,0 +1,89 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe 'ssh_keys' do
+  let(:base_cmd) { ['user', 'ssh-keys'] }
+  let(:user) do
+    {
+     :id => 1,
+     :name => 'admin'
+    }
+  end
+  let(:ssh_key) do
+    {
+      :id => 1,
+      :user_id => user[:id],
+      :name => 'SSH Key',
+      :fingerprint => 'FINGERPRINT',
+      :key => 'KEY',
+      :lenght => 256
+    }
+  end
+
+  describe 'list' do
+    let(:cmd) { base_cmd << 'list' }
+
+    it 'lists all ssh-keys for a given user' do
+      params = ['--user-id', user[:id]]
+      api_expects(:ssh_keys, :index, :user_id => user[:id])
+        .returns(index_response([ssh_key]))
+
+      expected_result = success_result(/#{ssh_key[:name]}/)
+
+      result = run_cmd(cmd + params)
+      assert_cmd(expected_result, result)
+    end
+  end
+
+  describe 'add' do
+    let(:cmd) { base_cmd << 'add' }
+
+    it 'adds an ssh-key to a given user' do
+      params = ['--user-id', user[:id],
+                '--key', ssh_key[:key],
+                '--name', ssh_key[:name]]
+      api_expects(:ssh_keys, :create, params)
+        .returns(ssh_key)
+
+      expected_result = success_result("SSH Key #{ssh_key[:name]} added\n")
+
+      result = run_cmd(cmd + params)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'adds an ssh-key to a given user with a key-file' do
+      params = ['--user-id', user[:id],
+                '--key-file', '~/.ssh/id_rsa.pub',
+                '--name', ssh_key[:name]]
+      File.stubs(:read).returns(ssh_key[:key])
+      api_expects(:ssh_keys, :create, {
+        :user_id => user[:id],
+        :ssh_key => {
+          :user_id => user[:id],
+          :key => ssh_key[:key],
+          :name => ssh_key[:name]
+        }
+      }).returns(ssh_key)
+
+      expected_result = success_result("SSH Key #{ssh_key[:name]} added\n")
+
+      result = run_cmd(cmd + params)
+      assert_cmd(expected_result, result)
+    end
+  end
+
+  describe 'delete' do
+    let(:cmd) { base_cmd << 'delete' }
+
+    it 'deletes an ssh-key to a given user' do
+      params = ['--id', ssh_key[:id],
+                '--user-id', user[:id]]
+      api_expects(:ssh_keys, :destroy, :id => ssh_key[:id])
+        .returns({})
+
+      expected_result = success_result("SSH Key deleted\n")
+
+      result = run_cmd(cmd + params)
+      assert_cmd(expected_result, result)
+    end
+  end
+end


### PR DESCRIPTION
The pull request will add commands to hammer to manage users' ssh-keys with the following commands:

```
hammer user ssh-keys list ...
hammer user ssh-keys add ...
hammer user ssh-keys delete ...
```
Two things I would need some guidance on:
- The commands are implemented, but still need to be made subcommands of 'user'. 
- Tests are based on what is in other unit tests, but fail and I can't make out what is still missing to make it work. 