### PR TITLE
Fixes #18750 - added more fields to hostgroup and host info command

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -61,9 +61,9 @@ module HammerCLIForeman
         field nil, _("Host Group"), Fields::SingleReference, :key => :hostgroup, :display_field => 'title'
         field nil, _("Compute Resource"), Fields::SingleReference, :key => :compute_resource
         field nil, _("Compute Profile"), Fields::SingleReference, :key => :compute_profile, :hide_blank => true
-        field nil, _("Environment"), Fields::SingleReference, :key => :environment
-        field :puppet_ca_proxy_id, _("Puppet CA Id")
-        field :puppet_proxy_id, _("Puppet Master Id")
+        field nil, _("Puppet Environment"), Fields::SingleReference, :key => :environment
+        field nil, _("Puppet CA Proxy"), Fields::SingleReference, :key => :puppet_ca_proxy
+        field nil, _("Puppet Master Proxy"), Fields::SingleReference, :key => :puppet_proxy
         field :certname, _("Cert name")
         field :managed, _("Managed"), Fields::Boolean
 
@@ -71,9 +71,11 @@ module HammerCLIForeman
         field :last_report, _("Last report"), Fields::Date
 
         label _("Network") do
-          field :ip, _("IP")
+          field :ip, _("IPv4 address"), Fields::Field, :hide_blank => true
+          field :ip6, _("IPv6 address"), Fields::Field, :hide_blank => true
           field :mac, _("MAC")
-          field nil, _("Subnet"), Fields::SingleReference, :key => :subnet
+          field nil, _("Subnet ipv4"), Fields::SingleReference, :key => :subnet
+          field nil, _("Subnet ipv6"), Fields::SingleReference, :key => :subnet6
           field nil, _("Domain"), Fields::SingleReference, :key => :domain
           field nil, _("Service provider"), Fields::Label, :hide_blank => true do
             field :sp_name, _("SP Name"), Fields::Field, :hide_blank => true
@@ -88,7 +90,8 @@ module HammerCLIForeman
           field :identifier, _('Identifier')
           field :_type, _('Type')
           field :mac, _('MAC address')
-          field :ip, _('IP address')
+          field :ip, _('IPv4 address'), Fields::Field, :hide_blank => true
+          field :ip6, _('IPv6 address'), Fields::Field, :hide_blank => true
           field :fqdn, _('FQDN')
         end
 
@@ -100,6 +103,7 @@ module HammerCLIForeman
           field :build, _("Build"), Fields::Boolean
           field nil, _("Medium"), Fields::SingleReference, :key => :medium
           field nil, _("Partition Table"), Fields::SingleReference, :key => :ptable
+          field :pxe_loader, _("PXE Loader"), Fields::Field, :hide_blank => true
           field :disk, _("Custom partition table"), Fields::LongText
           # image
           # for image based

--- a/lib/hammer_cli_foreman/hostgroup.rb
+++ b/lib/hammer_cli_foreman/hostgroup.rb
@@ -61,7 +61,7 @@ module HammerCLIForeman
         field :name, _("Name")
         field :title, _("Title")
         field nil, _("Operating System"), Fields::SingleReference, :key => :operatingsystem
-        field nil, _("Environment"), Fields::SingleReference, :key => :environment
+        field nil, _("Puppet Environment"), Fields::SingleReference, :key => :environment
         field nil, _("Model"), Fields::SingleReference, :key => :model
       end
 
@@ -73,19 +73,26 @@ module HammerCLIForeman
 
       output ListCommand.output_definition do
         field :description, _("Description"), Fields::LongText, :hide_blank => true
-        field nil, _("Subnet"), Fields::SingleReference, :key => :subnet
-
-        field nil, _("Domain"), Fields::SingleReference, :key => :domain
-        field nil, _("Architecture"), Fields::SingleReference, :key => :architecture
-        field nil, _("Partition Table"), Fields::SingleReference, :key => :ptable
-        field nil, _("Medium"), Fields::SingleReference, :key => :medium
-        field :puppet_ca_proxy_id, _("Puppet CA Proxy Id")
-        field :puppet_proxy_id, _("Puppet Master Proxy Id")
+        field nil, _("Parent"), Fields::SingleReference, :key => :parent, :hide_blank => true
+        field nil, _("Puppet CA Proxy"), Fields::SingleReference, :key => :puppet_ca_proxy
+        field nil, _("Puppet Master Proxy"), Fields::SingleReference, :key => :puppet_proxy
         field nil, _("ComputeProfile"), Fields::SingleReference, :key => :compute_profile
+        label _('Network') do
+          field nil, _("Subnet ipv4"), Fields::SingleReference, :key => :subnet
+          field nil, _("Subnet ipv6"), Fields::SingleReference, :key => :subnet6
+          field nil, _("Realm"), Fields::SingleReference, :key => :realm
+          field nil, _("Domain"), Fields::SingleReference, :key => :domain
+        end
+        label _('Operating system') do
+          field nil, _("Architecture"), Fields::SingleReference, :key => :architecture
+          field nil, _("Operating System"), Fields::SingleReference, :key => :operatingsystem
+          field nil, _("Medium"), Fields::SingleReference, :key => :medium
+          field nil, _("Partition Table"), Fields::SingleReference, :key => :ptable
+          field :pxe_loader, _("PXE Loader"), Fields::Field, :hide_blank => true
+        end
         HammerCLIForeman::References.puppetclasses(self)
         HammerCLIForeman::References.parameters(self)
         HammerCLIForeman::References.taxonomies(self)
-        field :ancestry, _("Parent Id")
       end
 
       build_options
@@ -103,6 +110,7 @@ module HammerCLIForeman
 
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
+
       include HostgroupUpdateCreateCommons
 
       success_message _("Hostgroup updated")

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -45,8 +45,8 @@ describe HammerCLIForeman::Host do
       with_params ["--id=1"] do
         it_should_print_n_records 1
         it_should_print_columns ["Id", "Name", "Organization", "Location"]
-        it_should_print_columns ["Host Group", "Compute Resource", "Compute Profile", "Environment"]
-        it_should_print_columns ["Puppet CA Id", "Puppet Master Id", "Cert name"]
+        it_should_print_columns ["Host Group", "Compute Resource", "Compute Profile", "Puppet Environment"]
+        it_should_print_columns ["Puppet CA Proxy", "Puppet Master Proxy", "Cert name"]
         it_should_print_columns ["Managed", "Installed at", "Last report"]
         it_should_print_columns ["Network", "Network interfaces", "Operating system", "Parameters", "All parameters", "Additional info"]
       end

--- a/test/unit/hostgroup_test.rb
+++ b/test/unit/hostgroup_test.rb
@@ -24,7 +24,7 @@ describe HammerCLIForeman::Hostgroup do
 
       it_should_print_n_records
       it_should_print_columns ["Id", "Name", "Title", "Operating System"]
-      it_should_print_columns ["Environment", "Model"]
+      it_should_print_columns ["Puppet Environment", "Model"]
     end
 
   end
@@ -41,9 +41,11 @@ describe HammerCLIForeman::Hostgroup do
     context "output" do
       with_params ["--id=1"] do
         it_should_print_n_records 1
-        it_should_print_columns ["Id", "Name", "Title", "Operating System", "Subnet"]
-        it_should_print_columns ["Domain", "Environment", "Puppetclasses", "Parent Id"]
+        it_should_print_columns ["Id", "Name", "Title", "Operating System"]
+        it_should_print_columns ["Puppet Environment", "Puppetclasses", "Parent"]
+        it_should_print_columns ["Puppet CA Proxy", "Puppet Master Proxy"]
         it_should_print_columns ["Parameters", "Description"]
+        it_should_print_columns ["Network", "Operating system"]
       end
     end
 


### PR DESCRIPTION
Foreman [PR]theforeman/foreman#4776 which is needed for this change is merged now.
Not created separate label for "Activation-Keys" as it is already listed under parameters label.

After renaming branch,I have created this PR as old [PR-326](https://github.com/theforeman/hammer-cli-foreman/pull/326) closed now.
