### PR TITLE
Refs #20476 - Add show command for ssh-keys

### DIFF
--- a/lib/hammer_cli_foreman/ssh_keys.rb
+++ b/lib/hammer_cli_foreman/ssh_keys.rb
@@ -36,6 +36,14 @@ module HammerCLIForeman
       build_options
     end
 
+    class InfoCommand < HammerCLIForeman::InfoCommand
+      output ListCommand.output_definition do
+        field :key, _("Public Key")
+      end
+
+      build_options
+    end
+
     class DeleteCommand < HammerCLIForeman::DeleteCommand
       success_message _("SSH Key deleted")
       failure_message _("Could not delete the SSH Key")

--- a/test/functional/ssh_keys_test.rb
+++ b/test/functional/ssh_keys_test.rb
@@ -71,6 +71,22 @@ describe 'ssh_keys' do
     end
   end
 
+  describe 'info' do
+    let(:cmd) { base_cmd << 'info' }
+
+    it 'shows the public key' do
+      params = ['--id', ssh_key[:id],
+                '--user-id', user[:id]]
+      api_expects(:ssh_keys, :show, :id => ssh_key[:id])
+        .returns(ssh_key)
+
+      expected_result = success_result(/#{ssh_key[:key]}/)
+
+      result = run_cmd(cmd + params)
+      assert_cmd(expected_result, result)
+    end
+  end
+
   describe 'delete' do
     let(:cmd) { base_cmd << 'delete' }
 


### PR DESCRIPTION
A follow up on #329 to add a show command for ssh-keys that includes the public key as well.

Example:
```shell
$ hammer user ssh-keys show --user-id 4 --id 1
Id:          1
Name:        bastilian@bastilian.local
Fingerprint: c1:e0:a7:7c:06:7d:f5:c3:po:r2:d2:d7:a5:0e:9b:42
Length:      256
Created at:  2017/09/19 08:53:35
Public Key:  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINDirKN2unK1h/3sXNp7KsCbwF86YLVPJfGLgwDjrnZI bastilian@bastilian.local
```