### PR TITLE
Fixes #20742 - Make hammer host reports work

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -213,12 +213,33 @@ module HammerCLIForeman
     end
 
 
-    class ReportsCommand < HammerCLIForeman::AssociatedResourceListCommand
+    class ReportsCommand < HammerCLIForeman::ListCommand
       command_name "reports"
       resource :reports, :index
-      parent_resource :hosts
+
+      option('--id', "ID", _('Host id'), :referenced_resource => 'host')
+      option('--name', "NAME", _('Host name'))
 
       output HammerCLIForeman::Report::ListCommand.output_definition
+     
+      def validate_options
+        validator.any(:option_name, :option_id).required
+      end
+
+      def request_params
+        params = super
+        search = []
+        search << params['search'] if params['search']
+        
+        hostname = get_option_value('name')
+        search << %Q(host="#{hostname}") if hostname
+        
+        host_id = get_option_value('id')
+        search << "host_id=#{host_id}" if host_id
+        
+        params['search'] = search.join(' and ') unless search.empty?
+        params
+      end
 
       build_options
     end

--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -52,7 +52,7 @@ module HammerCLIForeman
       :ptable =>           [ s_name(_("Partition table name")) ],
       :proxy =>            [ s_name(_("Proxy name")) ],
       :puppetclass =>      [ s_name(_("Puppet class name")) ],
-      :report =>           [ s_name(_("Report name")) ],
+      :report =>           [],
       :role =>             [ s_name(_("User role name")) ],
       :setting =>          [ s_name(_("Setting name"), :editable => false) ],
       :subnet =>           [ s_name(_("Subnet name")) ],


### PR DESCRIPTION
Added proper mapping of id and name options to search queries. Made host
parameter required. I found out there is no name in reports and fixed
the id resolver. --search was fixed. Added some tests.