### PR TITLE
Fixes #20607 - Allow hiding fields which are missing from api output

### DIFF
--- a/test/unit/test_output_adapter.rb
+++ b/test/unit/test_output_adapter.rb
@@ -13,7 +13,17 @@ class TestAdapter < HammerCLI::Output::Adapter::Abstract
     puts @separator+fields.collect{|f| f.label.to_s}.join(@separator)+@separator
 
     data.collect do |d|
-      puts @separator+fields.collect{ |f| data_for_field(f, d).to_s }.join(@separator)+@separator
+      fields_data = fields.collect do |f|
+        begin
+          data_for_field(f, d).to_s
+        rescue HammerCLI::MissingAPIError
+          # This is a workaround for current testing, which makes impossible to
+          # test http://projects.theforeman.org/issues/20607 feature becouse of
+          # simplified adapter.
+          nil.to_s
+        end
+      end.join(@separator)
+      puts "#{@separator}#{fields_data}#{@separator}"
     end
   end
 


### PR DESCRIPTION
Depends on https://github.com/theforeman/hammer-cli/pull/256