### PR TITLE
Fixes #21768 - Allow nil searchables [WIP]

### DIFF
--- a/doc/name_id_resolution.md
+++ b/doc/name_id_resolution.md
@@ -15,6 +15,7 @@ ID resolution step by step
 
 `IdResolver` implements the method `<resource_name>_id(cli_options)` for each of the resources. Under the hood, the method:
 - returns `cli_options['option_id']` if it's not nil
+- returns HammerCLI::NilValue if the correspondent search option is set to HammerCLI::NilValue (i.e. NIL specified on CLI)
 - looks at `index` method's parameters, finds all required `*_id` params there and makes sure they're present (if not it tries to resolve them recursively)
 - extends the original options with a `search` field that searches for the name
 - calls the `index` method and returns the result
@@ -24,6 +25,15 @@ It can end up with an exception when:
 - one of the dependent resources couldn't be found
 - the resource was not found
 - more resources were found
+
+Differences in resolution of list of id's
+-----------------------------------------
+
+the lookup method is called `<resource_name>_ids` and in addition:
+- returns `cli_options['option_ids']` if it's not nil
+- returns empty list (`[]`) when the search option is set to empty string or empty list 
+
+It also ends up with exception when any of the ids was not resolved.
 
 APIdoc requirements
 -------------------
@@ -46,5 +56,20 @@ Option builders should take care of all the requirements for you, but just for t
 Behaviour tuning
 ----------------
 
-Most of the resources are searchable by name. However there are exceptions that either don't have a name or offer more searchable fields. In such cases you have to update [the definition of searchable fields](https://github.com/theforeman/hammer-cli-foreman/blob/master/lib/hammer_cli_foreman/id_resolver.rb#L31).
+The resolution can be tuned at various levels.
 
+Most of the resources are searchable by name. However there are exceptions that either don't have a name 
+or offer more searchable fields. In such cases you have to update the definition 
+of searchable fields (SEARCHABLES) in [id_resolver](https://github.com/theforeman/hammer-cli-foreman/blob/master/lib/hammer_cli_foreman/id_resolver.rb).
+
+If you need to modify the lookup query (the `search` field) you can override the default one by adding a method 
+returning the correct lookup options to the resolver class.
+The method should be called according to the following schema: 
+- `create_<resource_name>_search_options(options)` for single id lookup (takes precedence over the next one for single id lookups) 
+- `create_<resource_plural_name>_search_options(options)` combine for single and/or multiple ids lookup 
+- `create_<resource_plural_name>_search_options(options, mode)` combined with extra parameter suggesting the lookup mode and being set to `:single`, `:multi` or `nil`
+
+For examples check the `id_resolver`.
+
+It is possible to completely override the resolution procedure by adding a method(s) called `<resource_name>_id` and/or `<resource_name>_ids` to the `id_resolver`.
+It will get the options hash as an input and expects `id` (list of `ids` respectively) or a `ResolverError` on its return.

--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -26,7 +26,7 @@ EOF
   s.require_paths = ["lib"]
 
   s.add_dependency 'hammer_cli', '>= 0.11.0'
-  s.add_dependency 'apipie-bindings', '>= 0.2.0'
+  s.add_dependency 'apipie-bindings', '>= 0.2.2'
   s.add_dependency 'rest-client', '>= 1.8.0', '< 3.0.0'
 
 end

--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -18,6 +18,7 @@ module HammerCLIForeman
   require 'hammer_cli_foreman/param_filters'
   require 'hammer_cli_foreman/id_resolver'
   require 'hammer_cli_foreman/dependency_resolver'
+  require 'hammer_cli_foreman/option_sources'
 
   begin
     require 'hammer_cli_foreman/commands'

--- a/lib/hammer_cli_foreman/filter.rb
+++ b/lib/hammer_cli_foreman/filter.rb
@@ -46,7 +46,10 @@ module HammerCLIForeman
 
       def self.included(base)
         def taxonomy_options?
-          option_location_names || option_location_ids || option_organization_names || option_organization_ids
+          opt_names = ['location_ids', 'organization_ids']
+          opt_names += resolver.searchables(:locations).map { |s| 'location_' + s.plural_name }
+          opt_names += resolver.searchables(:organizations).map { |s| 'organization_' + s.plural_name }
+          opt_names.any? { |opt| send(HammerCLI.option_accessor_name(opt)) }
         end
 
         def signal_override_usage_error

--- a/lib/hammer_cli_foreman/filter.rb
+++ b/lib/hammer_cli_foreman/filter.rb
@@ -43,17 +43,18 @@ module HammerCLIForeman
 
 
     module TaxonomyCheck
-      def taxonomy_options?
-        option_location_names || option_location_ids || option_organization_names || option_organization_ids
-      end
-
-      def signal_override_usage_error
-        signal_usage_error _('Organizations and locations can be set only for overriding filters')
-      end
 
       def self.included(base)
+        def taxonomy_options?
+          option_location_names || option_location_ids || option_organization_names || option_organization_ids
+        end
+
+        def signal_override_usage_error
+          signal_usage_error _('Organizations and locations can be set only for overriding filters')
+        end
+
         base.extend_help do |h|
-          h.section('Overriding organizations and locations') do
+          h.section(_('Overriding organizations and locations')) do
             override_condition = "--override=true"
             org_opts = '--organization[s|-ids]'
             loc_opts = '--location[s|-ids]'
@@ -76,9 +77,8 @@ module HammerCLIForeman
       success_message _("Permission filter for [%<resource_type>s] created")
       failure_message _("Could not create the permission filter")
 
-      def execute
+      def validate_options
         signal_override_usage_error if !option_override && taxonomy_options?
-        super
       end
 
       build_options
@@ -101,9 +101,8 @@ module HammerCLIForeman
         params
       end
 
-      def execute
+      def validate_options
         signal_override_usage_error if !override? && taxonomy_options?
-        super
       end
 
       def override?
@@ -115,7 +114,7 @@ module HammerCLIForeman
       end
 
       def filter
-        @filter ||= HammerCLIForeman.foreman_resource!(:filters).action(:show).call({ :id => option_id }, request_headers, request_options)
+        @filter ||= HammerCLIForeman.foreman_resource!(:filters).action(:show).call({ :id => get_identifier }, request_headers, request_options)
       end
 
       build_options
@@ -161,7 +160,6 @@ module HammerCLIForeman
 
     autoload_subcommands
   end
-
 end
 
 

--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -117,6 +117,11 @@ module HammerCLIForeman
       options[HammerCLI.option_accessor_name("ids")] || find_puppetclasses(options).collect { |c| c['id'] }
     end
 
+    def searchables(resource)
+      resource = @api.resource(resource) if resource.is_a? Symbol
+      @searchables.for(resource)
+    end
+
     protected
 
     def define_id_finders
@@ -254,10 +259,6 @@ module HammerCLIForeman
       end
       raise MissingSearchOptions.new(_("Missing options to search %s") % resource.singular_name, resource) if search_options.empty?
       search_options
-    end
-
-    def searchables(resource)
-      @searchables.for(resource)
     end
 
     def expected_record_count(options, resource)

--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -145,8 +145,9 @@ module HammerCLIForeman
         ids
       elsif (ids = nil_from_searchables(resource_name, options, :plural => true))
         ids
-      elsif options_nil?(@api.resource(resource_name), options)
-        nil
+      elsif options_not_set?(@api.resource(resource_name), options)
+        resource = @api.resource(resource_name)
+        raise MissingSearchOptions.new(_("Missing options to search %s") % resource.name, resource)
       elsif options_empty?(@api.resource(resource_name), options)
         []
       else
@@ -284,16 +285,16 @@ module HammerCLIForeman
     end
 
     def options_empty?(resource, options)
-      !searchables(resource).any? do |s|
+      searchables(resource).all? do |s|
         values = options[HammerCLI.option_accessor_name(s.plural_name.to_s)]
-        !values.nil? && values.respond_to?(:empty?) && !values.empty?
+        values.nil? || (values.respond_to?(:empty?) && values.empty?)
       end
     end
 
-    def options_nil?(resource, options)
-      !searchables(resource).any? do |s|
+    def options_not_set?(resource, options)
+      searchables(resource).all? do |s|
         values = options[HammerCLI.option_accessor_name(s.plural_name.to_s)]
-        !values.nil?
+        values.nil?
       end
     end
 

--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -135,9 +135,9 @@ module HammerCLIForeman
     end
 
     def get_id(resource_name, options)
-      options[HammerCLI.option_accessor_name("id")] || 
-	      nil_from_searchables(resource_name, options) ||
-        find_resource(resource_name, options)['id']
+      options[HammerCLI.option_accessor_name("id")] ||
+          nil_from_searchables(resource_name, options) ||
+          find_resource(resource_name, options)['id']
     end
 
     def get_ids(resource_name, options)

--- a/lib/hammer_cli_foreman/option_sources.rb
+++ b/lib/hammer_cli_foreman/option_sources.rb
@@ -1,0 +1,3 @@
+require 'hammer_cli_foreman/option_sources/id_params'
+require 'hammer_cli_foreman/option_sources/ids_params'
+require 'hammer_cli_foreman/option_sources/self_param'

--- a/lib/hammer_cli_foreman/option_sources.rb
+++ b/lib/hammer_cli_foreman/option_sources.rb
@@ -1,3 +1,4 @@
 require 'hammer_cli_foreman/option_sources/id_params'
 require 'hammer_cli_foreman/option_sources/ids_params'
 require 'hammer_cli_foreman/option_sources/self_param'
+require 'hammer_cli_foreman/option_sources/user_params'

--- a/lib/hammer_cli_foreman/option_sources/id_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/id_params.rb
@@ -31,11 +31,11 @@ module HammerCLIForeman
         end
 
         raise MissingSearchOptions.new(
-            error_message % {
-                :resource => e.resource.singular_name,
-                :switches => switches.join(", ")
-            },
-            e.resource
+          error_message % {
+            :resource => e.resource.singular_name,
+            :switches => switches.join(", ")
+          },
+          e.resource
         )
       end
     end

--- a/lib/hammer_cli_foreman/option_sources/id_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/id_params.rb
@@ -1,0 +1,43 @@
+module HammerCLIForeman
+  module OptionSources
+    class IdParams
+      def initialize(command)
+        @command = command
+      end
+
+      def get_options(defined_options, result)
+        # resolve all '<resource_name>_id' parameters if they are defined as options
+        # (they can be skipped using .without or .expand.except)
+        return result if @command.action.nil?
+        IdParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action)).each do |api_param|
+          param_resource = HammerCLIForeman.param_to_resource(api_param.name)
+          if param_resource && @command.respond_to?(HammerCLI.option_accessor_name("#{param_resource.singular_name}_id"))
+            resource_id = @command.get_resource_id(param_resource, :scoped => true, :required => api_param.required?, :all_options => result)
+            result[HammerCLI.option_accessor_name(api_param.name)] = resource_id if resource_id
+          end
+        end
+        result
+
+      rescue HammerCLIForeman::MissingSearchOptions => e
+
+        switches = @command.class.find_options(:referenced_resource => e.resource.singular_name).map(&:long_switch)
+
+        if switches.empty?
+          error_message = _("Could not find %{resource}. Some search options were missing, please see --help.")
+        elsif switches.length == 1
+          error_message = _("Could not find %{resource}, please set option %{switches}.")
+        else
+          error_message = _("Could not find %{resource}, please set one of options %{switches}.")
+        end
+
+        raise MissingSearchOptions.new(
+            error_message % {
+                :resource => e.resource.singular_name,
+                :switches => switches.join(", ")
+            },
+            e.resource
+        )
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/option_sources/ids_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/ids_params.rb
@@ -1,0 +1,22 @@
+module HammerCLIForeman
+  module OptionSources
+    class IdsParams
+      def initialize(command)
+        @command = command
+      end
+
+      def get_options(defined_options, result)
+        return result if @command.action.nil?
+        # resolve all '<resource_name>_ids' parameters if they are defined as options
+        IdArrayParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action)).each do |api_param|
+          param_resource = HammerCLIForeman.param_to_resource(api_param.name)
+          if param_resource && @command.respond_to?(HammerCLI.option_accessor_name("#{param_resource.singular_name}_ids"))
+            resource_ids = @command.get_resource_ids(param_resource, :scoped => true, :required => api_param.required?, :all_options => result)
+            result[HammerCLI.option_accessor_name(api_param.name)] = resource_ids if resource_ids
+          end
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/option_sources/self_param.rb
+++ b/lib/hammer_cli_foreman/option_sources/self_param.rb
@@ -1,0 +1,16 @@
+module HammerCLIForeman
+  module OptionSources
+    class SelfParam
+      def initialize(command)
+        @command = command
+      end
+
+      def get_options(defined_options, result)
+        # resolve 'id' parameter if it's defined as an option
+        id_option_name = HammerCLI.option_accessor_name('id')
+        result[id_option_name] ||= @command.get_identifier(result) if @command.respond_to?(id_option_name)
+        result
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/option_sources/user_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/user_params.rb
@@ -5,10 +5,6 @@ module HammerCLIForeman
         @command = command
       end
 
-      def option_name(opt_name)
-        HammerCLI.option_accessor_name(opt_name)
-      end
-
       def get_options(defined_options, result)
         org_id = organization_id(result[option_name(:default_organization)])
         result[option_name(:default_organization_id)] ||= org_id unless org_id.nil?
@@ -30,6 +26,12 @@ module HammerCLIForeman
         end
 
         result
+      end
+
+      private
+
+      def option_name(opt_name)
+        HammerCLI.option_accessor_name(opt_name)
       end
 
       def ask_password(type)

--- a/lib/hammer_cli_foreman/option_sources/user_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/user_params.rb
@@ -1,0 +1,57 @@
+module HammerCLIForeman
+  module OptionSources
+    class UserParams
+      def initialize(command)
+        @command = command
+      end
+
+      def option_name(opt_name)
+        HammerCLI.option_accessor_name(opt_name)
+      end
+
+      def get_options(defined_options, result)
+        org_id = organization_id(result[option_name(:default_organization)])
+        result[option_name(:default_organization_id)] ||= org_id unless org_id.nil?
+        loc_id = location_id(result[option_name(:default_location)])
+        result[option_name(:default_location_id)] ||= loc_id unless loc_id.nil?
+
+        if @command.action == :update
+          if result[option_name(:password)] || result[option_name(:ask_password)]
+            if current_logged_user["id"].to_s == result[option_name(:id)].to_s
+              unless result[option_name(:current_password)]
+                result[option_name(:current_password)] = ask_password(:current)
+              end
+            end
+          end
+        end
+
+        if result[option_name(:ask_password)]
+          result[option_name(:password)] = ask_password(:new)
+        end
+
+        result
+      end
+
+      def ask_password(type)
+        if type == :current
+          prompt = _("Enter user's current password:") + " "
+        elsif type == :new
+          prompt = _("Enter user's new password:") + " "
+        end
+        ask(prompt) {|q| q.echo = false}
+      end
+
+      def organization_id(name)
+        @command.resolver.organization_id('option_name' => name) if name
+      end
+
+      def location_id(name)
+        @command.resolver.location_id('option_name' => name) if name
+      end
+
+      def current_logged_user
+        HammerCLIForeman.foreman_api_connection.resource(:users).call(:show, :id => HammerCLIForeman.foreman_api_connection.authenticator.user(true))
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/user.rb
+++ b/lib/hammer_cli_foreman/user.rb
@@ -52,6 +52,7 @@ module HammerCLIForeman
     end
 
     module CommonUpdateOptions
+
       def self.included(base)
         base.option '--default-organization', 'DEFAULT_ORGANIZATION_NAME', _("Default organization name")
         base.option '--default-location', 'DEFAULT_LOCATION_NAME', _("Default location name")
@@ -59,39 +60,10 @@ module HammerCLIForeman
                     :format => HammerCLI::Options::Normalizers::Bool.new
       end
 
-      def self.ask_password(type)
-        if type == :current
-          prompt = _("Enter user's current password:") + " "
-        elsif type == :new
-          prompt = _("Enter user's new password:") + " "
-        end
-        ask(prompt) {|q| q.echo = false}
-      end
-
-      def current_logged_user
-        HammerCLIForeman.foreman_api_connection.resource(:users).call(:show, :id => HammerCLIForeman.foreman_api_connection.authenticator.user(true))
-      end
-
-      def request_params
-        params = super
-        org_id = organization_id(option_default_organization)
-        params['user']['default_organization_id'] ||= org_id unless org_id.nil?
-        loc_id = location_id(option_default_location)
-        params['user']['default_location_id'] ||= loc_id unless loc_id.nil?
-        params['user']['password'] = option_password unless option_password.nil?
-
-        if option_ask_password
-          params['user']['password'] = HammerCLIForeman::User::CommonUpdateOptions::ask_password(:new)
-        end
-        params
-      end
-
-      def organization_id(name)
-        resolver.organization_id('option_name' => name) if name
-      end
-
-      def location_id(name)
-        resolver.location_id('option_name' => name) if name
+      def option_sources
+        sources = super
+        sources << HammerCLIForeman::OptionSources::UserParams.new(self)
+        sources
       end
     end
 
@@ -100,6 +72,7 @@ module HammerCLIForeman
       failure_message _("Could not create the user")
 
       include CommonUpdateOptions
+
       build_options
     end
 
@@ -109,19 +82,6 @@ module HammerCLIForeman
       failure_message _("Could not update the user")
 
       include CommonUpdateOptions
-
-      def request_params
-        params = super
-
-        if (option_password || option_ask_password)
-          if current_logged_user["id"].to_s == params["id"].to_s
-            if (!option_current_password && (option_password || option_ask_password))
-              params['user']['current_password'] = HammerCLIForeman::User::CommonUpdateOptions::ask_password(:current)
-            end
-          end
-        end
-        params
-      end
 
       build_options
     end
@@ -133,6 +93,7 @@ module HammerCLIForeman
 
       build_options
     end
+
 
     HammerCLIForeman::AssociatingCommands::Role.extend_command(self)
     lazy_subcommand('ssh-keys', _("Managing User SSH Keys."),

--- a/lib/hammer_cli_foreman/user.rb
+++ b/lib/hammer_cli_foreman/user.rb
@@ -52,7 +52,6 @@ module HammerCLIForeman
     end
 
     module CommonUpdateOptions
-
       def self.included(base)
         base.option '--default-organization', 'DEFAULT_ORGANIZATION_NAME', _("Default organization name")
         base.option '--default-location', 'DEFAULT_LOCATION_NAME', _("Default location name")
@@ -72,7 +71,6 @@ module HammerCLIForeman
       failure_message _("Could not create the user")
 
       include CommonUpdateOptions
-
       build_options
     end
 
@@ -93,7 +91,6 @@ module HammerCLIForeman
 
       build_options
     end
-
 
     HammerCLIForeman::AssociatingCommands::Role.extend_command(self)
     lazy_subcommand('ssh-keys', _("Managing User SSH Keys."),

--- a/test/functional/filter_test.rb
+++ b/test/functional/filter_test.rb
@@ -28,6 +28,7 @@ describe 'filter' do
       params = ['--organization-ids=1,2', '--location-ids=3,4', '--override=false']
 
       api_expects_no_call
+
       result = run_cmd(@cmd + params)
       assert_cmd(taxonomy_usage_error('create', @cmd), result)
     end

--- a/test/functional/filter_test.rb
+++ b/test/functional/filter_test.rb
@@ -28,7 +28,6 @@ describe 'filter' do
       params = ['--organization-ids=1,2', '--location-ids=3,4', '--override=false']
 
       api_expects_no_call
-
       result = run_cmd(@cmd + params)
       assert_cmd(taxonomy_usage_error('create', @cmd), result)
     end

--- a/test/unit/helpers/command.rb
+++ b/test/unit/helpers/command.rb
@@ -10,7 +10,11 @@ class IdResolverTestProxy
   end
 
   def scoped_options(scope, options, mode = nil)
-    @original_resolver.scoped_options(scope, options)
+    @original_resolver.scoped_options(scope, options, mode)
+  end
+
+  def searchables(resource)
+    @original_resolver.searchables(resource)
   end
 
   protected

--- a/test/unit/helpers/command.rb
+++ b/test/unit/helpers/command.rb
@@ -9,7 +9,7 @@ class IdResolverTestProxy
     define_id_finders
   end
 
-  def scoped_options(scope, options)
+  def scoped_options(scope, options, mode = nil)
     @original_resolver.scoped_options(scope, options)
   end
 

--- a/test/unit/media_test.rb
+++ b/test/unit/media_test.rb
@@ -66,7 +66,7 @@ describe HammerCLIForeman::Medium do
     end
 
     with_params ["--name=medium_x", "--path=http://some.path/", "--operatingsystem-ids=1,2"] do
-      it_should_call_action :create, {'medium' => {'name' => 'medium_x', 'path' => 'http://some.path/', 'operatingsystem_ids' => [1]}}
+      it_should_call_action :create, {'medium' => {'name' => 'medium_x', 'path' => 'http://some.path/', 'operatingsystem_ids' => ['1','2']}}
     end
   end
 
@@ -95,7 +95,7 @@ describe HammerCLIForeman::Medium do
     end
 
     with_params ["--id=1", "--new-name=medium_x", "--path=http://some.path/", "--operatingsystem-ids=1,2"] do
-      it_should_call_action :update, {'id' => '1', 'name' => 'medium_x', 'medium' => {'name' => 'medium_x', 'path' => 'http://some.path/', 'operatingsystem_ids' => [1]}}
+      it_should_call_action :update, {'id' => '1', 'name' => 'medium_x', 'medium' => {'name' => 'medium_x', 'path' => 'http://some.path/', 'operatingsystem_ids' => ['1','2']}}
     end
 
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -89,7 +89,7 @@ describe HammerCLIForeman::User do
     let(:cmd) { cmd_module::UpdateCommand.new("", ctx) }
 
     before :each do
-      HammerCLIForeman::User::CommonUpdateOptions.stubs(:ask_password).returns("password")
+      HammerCLIForeman::OptionSources::UserParams.any_instance.stubs(:ask_password).returns("password")
     end
 
     context "parameters" do


### PR DESCRIPTION
Adds ability to correctly resolve name params set to NIL.

For better coexistence with hammer defaults the logic
was moved to option sources which is now prefered place
for manipulation with options. As a result when options
or all_options is called anywhere in the code it should
return fully resolved options in final state.

TODO:
- [x] convert request_params in user
- [x] tests
- [x] some docs

For testing the following is required:
- https://github.com/theforeman/hammer-cli/pull/264
- https://github.com/Apipie/apipie-bindings/pull/70
- optional but recommended is latest upstream with https://github.com/theforeman/foreman/pull/4917