### PR TITLE
Refs #22517 - Do not resolve already resolved id params

### DIFF
--- a/lib/hammer_cli_foreman/option_sources/id_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/id_params.rb
@@ -5,13 +5,21 @@ module HammerCLIForeman
         @command = command
       end
 
+      def param_updatable?(param_resource)
+        param_resource && @command.respond_to?(HammerCLI.option_accessor_name("#{param_resource.singular_name}_id"))
+      end
+
+      def available_id_params
+        IdParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action))
+      end
+
       def get_options(defined_options, result)
         # resolve all '<resource_name>_id' parameters if they are defined as options
         # (they can be skipped using .without or .expand.except)
         return result if @command.action.nil?
-        IdParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action)).each do |api_param|
+        available_id_params.each do |api_param|
           param_resource = HammerCLIForeman.param_to_resource(api_param.name)
-          if param_resource && @command.respond_to?(HammerCLI.option_accessor_name("#{param_resource.singular_name}_id"))
+          if result[HammerCLI.option_accessor_name(api_param.name)].nil? && param_updatable?(param_resource)
             resource_id = @command.get_resource_id(param_resource, :scoped => true, :required => api_param.required?, :all_options => result)
             result[HammerCLI.option_accessor_name(api_param.name)] = resource_id if resource_id
           end

--- a/lib/hammer_cli_foreman/option_sources/ids_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/ids_params.rb
@@ -5,12 +5,20 @@ module HammerCLIForeman
         @command = command
       end
 
+      def param_updatable?(param_resource)
+        param_resource && @command.respond_to?(HammerCLI.option_accessor_name("#{param_resource.singular_name}_ids"))
+      end
+
+      def available_ids_params
+        IdArrayParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action))
+      end
+
       def get_options(defined_options, result)
         return result if @command.action.nil?
         # resolve all '<resource_name>_ids' parameters if they are defined as options
-        IdArrayParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action)).each do |api_param|
+        available_ids_params.each do |api_param|
           param_resource = HammerCLIForeman.param_to_resource(api_param.name)
-          if param_resource && @command.respond_to?(HammerCLI.option_accessor_name("#{param_resource.singular_name}_ids"))
+          if result[HammerCLI.option_accessor_name(api_param.name)].nil? && param_updatable?(param_resource)
             resource_ids = @command.get_resource_ids(param_resource, :scoped => true, :required => api_param.required?, :all_options => result)
             result[HammerCLI.option_accessor_name(api_param.name)] = resource_ids if resource_ids
           end

--- a/test/unit/option_sources/id_params_test.rb
+++ b/test/unit/option_sources/id_params_test.rb
@@ -1,0 +1,27 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+
+describe HammerCLIForeman::OptionSources::IdParams do
+  describe "get_options" do
+    class IdParamsTestCommand < HammerCLIForeman::CreateCommand
+      resource :hostgroups
+      build_options
+    end
+
+    let(:hg_cmd) { IdParamsTestCommand.new("", { :adapter => :csv, :interactive => false }) }
+    let(:id_params_source) { HammerCLIForeman::OptionSources::IdParams.new(hg_cmd) }
+
+    it "skips param when set" do
+      hg_cmd.stubs(:get_resource_id).returns(1)
+      option_data = { 'option_domain_id' => 3, 'option_domain_name' => 'test' }
+      params = id_params_source.get_options([], option_data)
+      params.must_equal option_data
+    end
+
+    it "resolves param when unset" do
+      hg_cmd.stubs(:get_resource_id).returns(1)
+      option_data = { 'option_domain_id' => nil, 'option_domain_name' => 'test' }
+      params = id_params_source.get_options([], option_data)
+      params['option_domain_id'].must_equal 1
+    end
+  end
+end

--- a/test/unit/option_sources/id_params_test.rb
+++ b/test/unit/option_sources/id_params_test.rb
@@ -12,7 +12,7 @@ describe HammerCLIForeman::OptionSources::IdParams do
 
     it "skips param when set" do
       hg_cmd.expects(:get_resource_id).with { |res| res.name != :domains }.at_least(0).returns(nil)
-      hg_cmd.expects(:get_resource_id).with { |res| res.name == :domains }.never.returns(1)
+      hg_cmd.expects(:get_resource_id).with { |res| res.name == :domains }.never
       option_data = { 'option_domain_id' => 3, 'option_domain_name' => 'test' }
       params = id_params_source.get_options([], option_data)
       params.must_equal option_data

--- a/test/unit/option_sources/id_params_test.rb
+++ b/test/unit/option_sources/id_params_test.rb
@@ -11,7 +11,7 @@ describe HammerCLIForeman::OptionSources::IdParams do
     let(:id_params_source) { HammerCLIForeman::OptionSources::IdParams.new(hg_cmd) }
 
     it "skips param when set" do
-      hg_cmd.expects(:get_resource_id).with { |res| res.name != :domains }.at_least(0).returns(nil)
+      hg_cmd.stubs(:get_resource_id).returns(nil)
       hg_cmd.expects(:get_resource_id).with { |res| res.name == :domains }.never
       option_data = { 'option_domain_id' => 3, 'option_domain_name' => 'test' }
       params = id_params_source.get_options([], option_data)
@@ -19,7 +19,7 @@ describe HammerCLIForeman::OptionSources::IdParams do
     end
 
     it "resolves param when unset" do
-      hg_cmd.expects(:get_resource_id).with { |res| res.name != :domains }.at_least(0).returns(nil)
+      hg_cmd.stubs(:get_resource_id).returns(nil)
       hg_cmd.expects(:get_resource_id).with { |res| res.name == :domains }.returns(1)
       option_data = { 'option_domain_id' => nil, 'option_domain_name' => 'test' }
       expected_data = { 'option_domain_id' => 1, 'option_domain_name' => 'test' }

--- a/test/unit/option_sources/id_params_test.rb
+++ b/test/unit/option_sources/id_params_test.rb
@@ -11,17 +11,20 @@ describe HammerCLIForeman::OptionSources::IdParams do
     let(:id_params_source) { HammerCLIForeman::OptionSources::IdParams.new(hg_cmd) }
 
     it "skips param when set" do
-      hg_cmd.stubs(:get_resource_id).returns(1)
+      hg_cmd.expects(:get_resource_id).with { |res| res.name != :domains }.at_least(0).returns(nil)
+      hg_cmd.expects(:get_resource_id).with { |res| res.name == :domains }.never.returns(1)
       option_data = { 'option_domain_id' => 3, 'option_domain_name' => 'test' }
       params = id_params_source.get_options([], option_data)
       params.must_equal option_data
     end
 
     it "resolves param when unset" do
-      hg_cmd.stubs(:get_resource_id).returns(1)
+      hg_cmd.expects(:get_resource_id).with { |res| res.name != :domains }.at_least(0).returns(nil)
+      hg_cmd.expects(:get_resource_id).with { |res| res.name == :domains }.returns(1)
       option_data = { 'option_domain_id' => nil, 'option_domain_name' => 'test' }
+      expected_data = { 'option_domain_id' => 1, 'option_domain_name' => 'test' }
       params = id_params_source.get_options([], option_data)
-      params['option_domain_id'].must_equal 1
+      params.must_equal expected_data
     end
   end
 end

--- a/test/unit/option_sources/ids_params_test.rb
+++ b/test/unit/option_sources/ids_params_test.rb
@@ -11,17 +11,20 @@ describe HammerCLIForeman::OptionSources::IdsParams do
     let(:ids_params_source) { HammerCLIForeman::OptionSources::IdsParams.new(cmd) }
 
     it "skips param when set" do
-      cmd.stubs(:get_resource_ids).returns([1])
+      cmd.expects(:get_resource_ids).with { |res| res.name != :locations }.returns(nil)
+      cmd.expects(:get_resource_ids).with { |res| res.name == :locations }.never.returns([1])
       option_data = { 'option_location_ids' => [3], 'option_location_names' => 'test' }
       params = ids_params_source.get_options([], option_data)
       params.must_equal option_data
     end
 
     it "resolves param when unset" do
-      cmd.stubs(:get_resource_ids).returns([1])
-      option_data = { 'option_location_id' => nil, 'option_location_names' => 'test' }
+      cmd.expects(:get_resource_ids).with { |res| res.name != :locations }.returns(nil)
+      cmd.expects(:get_resource_ids).with { |res| res.name == :locations }.returns([1])
+      option_data = { 'option_location_ids' => nil, 'option_location_names' => 'test' }
+      expected_data = { 'option_location_ids' => [1], 'option_location_names' => 'test' }
       params = ids_params_source.get_options([], option_data)
-      params['option_location_ids'].must_equal [1]
+      params.must_equal expected_data
     end
   end
 end

--- a/test/unit/option_sources/ids_params_test.rb
+++ b/test/unit/option_sources/ids_params_test.rb
@@ -11,8 +11,8 @@ describe HammerCLIForeman::OptionSources::IdsParams do
     let(:ids_params_source) { HammerCLIForeman::OptionSources::IdsParams.new(cmd) }
 
     it "skips param when set" do
-      cmd.expects(:get_resource_ids).with { |res| res.name != :locations }.returns(nil)
-      cmd.expects(:get_resource_ids).with { |res| res.name == :locations }.never.returns([1])
+      cmd.expects(:get_resource_ids).with { |res| res.name != :locations }.at_least(0).returns(nil)
+      cmd.expects(:get_resource_ids).with { |res| res.name == :locations }.never
       option_data = { 'option_location_ids' => [3], 'option_location_names' => 'test' }
       params = ids_params_source.get_options([], option_data)
       params.must_equal option_data

--- a/test/unit/option_sources/ids_params_test.rb
+++ b/test/unit/option_sources/ids_params_test.rb
@@ -11,7 +11,7 @@ describe HammerCLIForeman::OptionSources::IdsParams do
     let(:ids_params_source) { HammerCLIForeman::OptionSources::IdsParams.new(cmd) }
 
     it "skips param when set" do
-      cmd.expects(:get_resource_ids).with { |res| res.name != :locations }.at_least(0).returns(nil)
+      cmd.stubs(:get_resource_ids).returns(nil)
       cmd.expects(:get_resource_ids).with { |res| res.name == :locations }.never
       option_data = { 'option_location_ids' => [3], 'option_location_names' => 'test' }
       params = ids_params_source.get_options([], option_data)
@@ -19,7 +19,7 @@ describe HammerCLIForeman::OptionSources::IdsParams do
     end
 
     it "resolves param when unset" do
-      cmd.expects(:get_resource_ids).with { |res| res.name != :locations }.returns(nil)
+      cmd.stubs(:get_resource_ids).returns(nil)
       cmd.expects(:get_resource_ids).with { |res| res.name == :locations }.returns([1])
       option_data = { 'option_location_ids' => nil, 'option_location_names' => 'test' }
       expected_data = { 'option_location_ids' => [1], 'option_location_names' => 'test' }

--- a/test/unit/option_sources/ids_params_test.rb
+++ b/test/unit/option_sources/ids_params_test.rb
@@ -1,0 +1,27 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+
+describe HammerCLIForeman::OptionSources::IdsParams do
+  describe "get_options" do
+    class IdsParamsTestCommand < HammerCLIForeman::CreateCommand
+      resource :users
+      build_options
+    end
+
+    let(:cmd) { IdsParamsTestCommand.new("", { :adapter => :csv, :interactive => false }) }
+    let(:ids_params_source) { HammerCLIForeman::OptionSources::IdsParams.new(cmd) }
+
+    it "skips param when set" do
+      cmd.stubs(:get_resource_ids).returns([1])
+      option_data = { 'option_location_ids' => [3], 'option_location_names' => 'test' }
+      params = ids_params_source.get_options([], option_data)
+      params.must_equal option_data
+    end
+
+    it "resolves param when unset" do
+      cmd.stubs(:get_resource_ids).returns([1])
+      option_data = { 'option_location_id' => nil, 'option_location_names' => 'test' }
+      params = ids_params_source.get_options([], option_data)
+      params['option_location_ids'].must_equal [1]
+    end
+  end
+end


### PR DESCRIPTION
Avoid resolving of id_parameters that are alredy set.
This allows overriding name resolving by adding
new option_source before the default ones.