### PR TITLE
Fixes #22552 - generate --provision-method from apidoc

### DIFF
--- a/lib/hammer_cli_foreman/hosts/common_update_options.rb
+++ b/lib/hammer_cli_foreman/hosts/common_update_options.rb
@@ -43,12 +43,10 @@ module HammerCLIForeman
           :format => HammerCLI::Options::Normalizers::KeyValueList.new
         base.option "--interface", "INTERFACE", _("Interface parameters"), :multivalued => true,
           :format => HammerCLI::Options::Normalizers::KeyValueList.new
-        base.option "--provision-method", "METHOD", " ",
-          :format => HammerCLI::Options::Normalizers::Enum.new(['build', 'image'])
 
         base.build_options :without => [
               # - temporarily disabled params that will be removed from the api ------------------
-              :provision_method, :capabilities, :flavour_ref, :image_ref, :start,
+              :capabilities, :flavour_ref, :image_ref, :start,
               :network, :cpus, :memory, :provider, :type, :tenant_id, :image_id,
               # ----------------------------------------------------------------------------------
               :puppet_class_ids, :host_parameters_attributes, :interfaces_attributes, :root_pass]


### PR DESCRIPTION
Not necessarily blocked, but it's probably better to test it together with:
https://github.com/theforeman/foreman/pull/5248