### PR TITLE
Fixes #22718 - raise error when wrong number of ids is resolved

### DIFF
--- a/lib/hammer_cli_foreman/id_resolver.rb
+++ b/lib/hammer_cli_foreman/id_resolver.rb
@@ -172,7 +172,7 @@ module HammerCLIForeman
     def find_resources(resource_name, options)
       resource = @api.resource(resource_name)
       results = resolved_call(resource_name, :index, options, :multi)
-      raise ResolverError.new(_("one of %s not found.") % resource.name, resource) if results.count < expected_record_count(options, resource)
+      raise ResolverError.new(_("one of %s not found.") % resource.name, resource) if results.count < expected_record_count(options, resource, :multi)
       results
     end
 
@@ -184,7 +184,7 @@ module HammerCLIForeman
         ids
       elsif !options_empty?(resource, options)
         results = resolved_call(resource_name, :index, options, :multi).first.values.flatten
-        raise ResolverError.new(_("one of %s not found.") % resource.name, resource) if results.count < expected_record_count(options, resource)
+        raise ResolverError.new(_("one of %s not found.") % resource.name, resource) if results.count < expected_record_count(options, resource, :multi)
         results
       else
         []
@@ -266,10 +266,11 @@ module HammerCLIForeman
       search_options
     end
 
-    def expected_record_count(options, resource)
+    # @param mode [Symbol] mode in which ids are searched :single, :multi, nil for old beahvior
+    def expected_record_count(options, resource, mode = nil)
       searchables(resource).each do |s|
-        value = options[HammerCLI.option_accessor_name(s.name.to_s)]
-        values = options[HammerCLI.option_accessor_name(s.plural_name.to_s)]
+        value = options[HammerCLI.option_accessor_name(s.name.to_s)] unless mode == :multi
+        values = options[HammerCLI.option_accessor_name(s.plural_name.to_s)] unless mode == :single
         if value
           return 1
         elsif values

--- a/test/unit/id_resolver_test.rb
+++ b/test/unit/id_resolver_test.rb
@@ -253,6 +253,14 @@ describe HammerCLIForeman::IdResolver do
         assert_equal [john_id, jane_id], resolver.user_ids({"option_names" => ["John Doe", "Jane Doe"]})
       end
 
+      it "raises exception when wrong number of resources is found even with conflicting options" do
+        ResourceMocks.mock_action_call(:users, :index, [john])
+
+        assert_raises HammerCLIForeman::ResolverError do
+          resolver.user_ids({"option_names" => ["John Doe", "Jane Doe"], "option_name" => "group1"})
+        end
+      end
+
       it "raises exception when wrong number of resources is found" do
         ResourceMocks.mock_action_call(:users, :index, [john])
 


### PR DESCRIPTION
reproducer, should fail with the patch:
```bash
hammer role create --name a
hammer user-group create --name ug1 --admin true --roles 'a,m'
```