### PR TITLE
Fixes #23401 - add MTU to subnet info

### DIFF
--- a/lib/hammer_cli_foreman/subnet.rb
+++ b/lib/hammer_cli_foreman/subnet.rb
@@ -32,6 +32,7 @@ module HammerCLIForeman
         field :gateway, _("Gateway")
         field :from, _("From")
         field :to, _("To")
+        field :mtu, _("MTU")
         HammerCLIForeman::References.domains(self)
         HammerCLIForeman::References.taxonomies(self)
         HammerCLIForeman::References.parameters(self)


### PR DESCRIPTION
This was added in Foreman 1.18 so if possible, should be added to hammer-cli-foreman released with it