### PR TITLE
Fixes #12189 - hammer report info doesn't show logs resources and mes…

### DIFF
--- a/lib/hammer_cli_foreman/config_report.rb
+++ b/lib/hammer_cli_foreman/config_report.rb
@@ -57,13 +57,11 @@ module HammerCLIForeman
           end
         end
         field :logs, _("Logs"), Fields::Collection do
-          from :log do
-            from :source do
-              field :source, _("Resource")
-            end
-            from :message do
-              field :message, _("Message")
-            end
+          from "source" do
+            field :source, _("Resource")
+          end
+          from "message" do
+            field :message, _("Message")
           end
         end
       end


### PR DESCRIPTION
Source and Message will show something now when shown with hammer report info --id=<someid> instead of
 1) Resource:
    Message: