### PR TITLE
Use SPDX 2.0 codes

### DIFF
--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Tomáš Strachota", "Martin Bačovský"]
   s.email         = "tstracho@redhat.com"
   s.homepage      = "https://github.com/theforeman/hammer-cli-foreman"
-  s.license       = "GPL-3.0-or-later"
+  s.license       = "GPL-3.0+"
 
   s.summary       = %q{Foreman commands for Hammer}
   s.description   = <<EOF


### PR DESCRIPTION
Ruby isn't using SPDX 3.0 codes yet so it still generates a warning.