### PR TITLE
Re-add --thin to fix #20072 and rhbz#1560978

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -36,7 +36,7 @@ module HammerCLIForeman
         field :global_status_label, _("Global Status")
       end
 
-      build_options :without => [:include, :thin]
+      build_options :without => [:include]
     end
 
 


### PR DESCRIPTION
Reverts #20754 to bring back #20072 ( https://projects.theforeman.org/issues/20072 )
Fixes rhbz#1560978 ( https://bugzilla.redhat.com/show_bug.cgi?id=1560978 )

Note that I did not test with a large DB but --thin seems to be indeed slightly faster, which could make a difference for 1K+ hosts.

~~~
# time hammer --csv host list --organization rht --location rdu
Id,Name,Operating System,Host Group,IP,MAC,Content View,Lifecycle Environment
2,test.example.org,RedHat 7.6,emptyHG,,00:00:00:00:00:00,cv7,dev

real	0m1.739s
user	0m1.295s
sys	0m0.167s
~~~

~~~
# time hammer --csv host list --organization rht --location rdu --thin 1
Id,Name,Operating System,Host Group,IP,MAC,Content View,Lifecycle Environment
2,test.example.org,"","",,,,

real	0m1.623s
user	0m1.306s
sys	0m0.150s
~~~
