### PR TITLE
Fixes #25848 - Adding SSO func. through CLI using OpenID Connect.

### DIFF
--- a/config/foreman.yml
+++ b/config/foreman.yml
@@ -6,8 +6,28 @@
   :host: 'https://localhost/'
 
   # Credentials. You'll be asked for them interactively if you leave them blank here
+  # Possible values:
+
+  # Basic Auth:
+  #:default_auth_type: 'Basic_Auth'
   :username: 'admin'
   #:password: 'example'
+
+  # Oauth using the Password Grant Flow:
+  # This authentication method requires sessions to be enabled, uncomment the following
+  # lines to use this authentication method.
+  #:default_auth_type: 'Oauth_Password_Grant'
+  #:oidc_token_endpoint: https://keycloak.example.com/token
+  #:oidc_client_id: example-client-id
+
+  # Oauth using Authentication Code Flow(Two Factor):
+  # This authentication method requires sessions to be enabled, uncomment the following
+  # lines to use this authentication method.
+  #:default_auth_type: 'Oauth_Authentication_Code_Grant'
+  #:oidc_token_endpoint: https://keycloak.example.com/token
+  #:oidc_authorization_endpoint: https://keycloak.example.com/auth
+  #:oidc_client_id: example-client-id
+  #:oidc_redirect_uri: urn:ietf:wg:oauth:2.0:oob
 
   # Enable using sessions
   # When sessions are enabled, hammer ignores credentials stored in the config file

--- a/hammer_cli_foreman.gemspec
+++ b/hammer_cli_foreman.gemspec
@@ -26,7 +26,8 @@ EOF
   s.require_paths = ["lib"]
 
   s.add_dependency 'hammer_cli', '>= 0.18.0'
-  s.add_dependency 'apipie-bindings', '>= 0.2.2'
+  s.add_dependency 'apipie-bindings', '>= 0.3.0'
   s.add_dependency 'rest-client', '>= 1.8.0', '< 3.0.0'
+  s.add_dependency 'jwt', '>= 2.2.1'
 
 end

--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -20,6 +20,7 @@ module HammerCLIForeman
   require 'hammer_cli_foreman/dependency_resolver'
   require 'hammer_cli_foreman/option_sources'
   require 'hammer_cli_foreman/logger'
+  require 'hammer_cli_foreman/sessions'
 
   begin
     require 'hammer_cli_foreman/command_extensions'

--- a/lib/hammer_cli_foreman/api/authenticator.rb
+++ b/lib/hammer_cli_foreman/api/authenticator.rb
@@ -1,0 +1,81 @@
+module HammerCLIForeman
+  module Api
+    class Authenticator
+      attr_accessor :auth_type, :uri, :settings
+      def initialize(auth_type, uri, settings)
+        @auth_type = auth_type
+        @uri = uri
+        @settings = settings
+      end
+
+      def fetch
+        if ssl_cert_authentication? && !use_basic_auth?
+          void_auth
+        elsif auth_type == AUTH_TYPES[:basic_auth]
+          basic_auth
+        elsif auth_type == AUTH_TYPES[:oauth_password_grant]
+          oauth_password_grant
+        elsif auth_type == AUTH_TYPES[:oauth_authentication_code_grant]
+          oauth_authentication_code_grant
+        end
+      end
+
+      private
+
+      def void_auth
+        VoidAuth.new(_('Using certificate authentication.'))
+      end
+
+      def basic_auth
+        if HammerCLIForeman::Sessions.enabled?
+          authenticator = InteractiveBasicAuth.new(
+            settings.get(:_params, :username) || ENV['FOREMAN_USERNAME'],
+            settings.get(:_params, :password) || ENV['FOREMAN_PASSWORD']
+          )
+          SessionAuthenticatorWrapper.new(authenticator, uri, auth_type)
+        else
+          username = settings.get(:_params, :username) || ENV['FOREMAN_USERNAME'] || settings.get(:foreman, :username)
+          password = settings.get(:_params, :password) || ENV['FOREMAN_PASSWORD']
+          if password.nil? && (username == settings.get(:foreman, :username))
+            password = settings.get(:foreman, :password)
+          end
+          InteractiveBasicAuth.new(username, password)
+        end
+      end
+
+      def oauth_password_grant
+        return unless HammerCLIForeman::Sessions.enabled?
+
+        authenticator = Oauth::PasswordGrant.new(
+          ENV['OIDC_TOKEN_ENDPOINT'] || settings.get(:foreman, :oidc_token_endpoint),
+          ENV['OIDC_CLIENT_ID'] || settings.get(:foreman, :oidc_client_id),
+          ENV['OIDC_USERNAME'],
+          ENV['OIDC_PASSWORD']
+        )
+        SessionAuthenticatorWrapper.new(authenticator, uri, auth_type)
+      end
+
+      def oauth_authentication_code_grant
+        return unless HammerCLIForeman::Sessions.enabled?
+
+        authenticator = Oauth::AuthenticationCodeGrant.new(
+          ENV['OIDC_TOKEN_ENDPOINT'] || settings.get(:foreman, :oidc_token_endpoint),
+          ENV['OIDC_AUTHORIZATION_URL'] || settings.get(:foreman, :oidc_authorization_endpoint),
+          ENV['OIDC_CLIENT_ID'] || settings.get(:foreman, :oidc_client_id),
+          ENV['OIDC_REDIRECT_URI'] || settings.get(:foreman, :oidc_redirect_uri)
+        )
+        SessionAuthenticatorWrapper.new(authenticator, uri, auth_type)
+      end
+
+      def ssl_cert_authentication?
+        (settings.get(:_params, :ssl_client_cert) || settings.get(:ssl, :ssl_client_cert)) &&
+          (settings.get(:_params, :ssl_client_key) || settings.get(:ssl, :ssl_client_key))
+      end
+
+      def use_basic_auth?
+        settings.get(:_params, :ssl_with_basic_auth) ||
+          settings.get(:ssl, :ssl_with_basic_auth)
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/api/interactive_basic_auth.rb
+++ b/lib/hammer_cli_foreman/api/interactive_basic_auth.rb
@@ -12,12 +12,12 @@ module HammerCLIForeman
       def error(ex)
         if ex.is_a?(RestClient::Unauthorized)
           self.clear
-          message = _("Invalid username or password.")
+          message = _('Invalid username or password.')
           begin
             message = JSON.parse(ex.response.body)['error']['message']
           rescue
           end
-          return UnauthorizedError.new(message)
+          UnauthorizedError.new(message)
         end
       end
 

--- a/lib/hammer_cli_foreman/api/oauth/authentication_code_grant.rb
+++ b/lib/hammer_cli_foreman/api/oauth/authentication_code_grant.rb
@@ -1,0 +1,100 @@
+require 'jwt'
+require 'hammer_cli_foreman/openid_connect'
+
+module HammerCLIForeman
+  module Api
+    module Oauth
+      class AuthenticationCodeGrant < ApipieBindings::Authenticators::TokenAuth
+        attr_accessor :oidc_token_endpoint, :oidc_authorization_endpoint, :oidc_client_id, :token, :oidc_redirect_uri
+
+        def initialize(oidc_token_endpoint, oidc_authorization_endpoint, oidc_client_id, oidc_redirect_uri)
+          @oidc_token_endpoint = oidc_token_endpoint
+          @oidc_authorization_endpoint = oidc_authorization_endpoint
+          @oidc_client_id = oidc_client_id
+          @oidc_redirect_uri = oidc_redirect_uri
+          super set_token(oidc_token_endpoint, oidc_authorization_endpoint, oidc_client_id, oidc_redirect_uri)
+        end
+
+        def authenticate(request, token)
+          if HammerCLI.interactive?
+            set_token_interactively
+          end
+          super
+        end
+
+        def set_token_interactively
+          @token ||= set_token(get_oidc_token_endpoint, get_oidc_authorization_endpoint, get_oidc_client_id, get_oidc_redirect_uri)
+        end
+
+        def set_token(input_oidc_token_endpoint, input_oidc_authorization_endpoint, input_oidc_client_id, input_oidc_redirect_uri)
+          @oidc_token_endpoint = input_oidc_token_endpoint if input_oidc_token_endpoint
+          @oidc_authorization_endpoint = input_oidc_authorization_endpoint if input_oidc_authorization_endpoint
+          @oidc_client_id = input_oidc_client_id if input_oidc_client_id
+          @oidc_redirect_uri = input_oidc_redirect_uri if input_oidc_redirect_uri
+
+          if @oidc_client_id && @oidc_authorization_endpoint && @oidc_redirect_uri && @oidc_token_endpoint
+            get_code
+            @token = HammerCLIForeman::OpenidConnect.new(
+              @oidc_token_endpoint, @oidc_client_id).get_token_via_2fa(@code, @oidc_redirect_uri)
+          else
+            @token = nil
+          end
+        end
+
+        def user
+          return nil unless @token
+          payload = JWT.decode(@token, nil, false)
+          payload.first["preferred_username"]
+        end
+
+        def error(ex)
+          if ex.is_a?(RestClient::InternalServerError)
+            @oidc_token_endpoint = @oidc_authorization_endpoint = @oidc_client_id = @oidc_client_id = nil
+            original_message = _("Invalid oidc-client-id or oidc-token-endpoint or oidc-authorization-endpoint.\n")
+            begin
+              message = JSON.parse(ex.response.body)['error']['message']
+            rescue
+            end
+            UnauthorizedError.new(original_message << message)
+          end
+        end
+
+        private
+
+        def get_code
+          @token_url = "#{@oidc_authorization_endpoint}?"\
+                        'response_type=code'\
+                        "&client_id=#{@oidc_client_id}"\
+                        "&redirect_uri=#{@oidc_redirect_uri}"\
+                        '&scope=openid'
+          HammerCLI.interactive_output.say("Enter URL in browser: #{@token_url}")
+          @code ||= ask_user(_("Code:%s") % " ")
+        end
+
+        def get_oidc_authorization_endpoint
+          @oidc_authorization_endpoint ||= ask_user(_("Openidc Provider Authorization Endpoint:%s") % " ")
+        end
+
+        def get_oidc_token_endpoint
+          @oidc_token_endpoint ||= ask_user(_("Openidc Provider Token Endpoint:%s") % " ")
+        end
+
+        def get_oidc_client_id
+          @oidc_client_id ||= ask_user(_("Client ID:%s") % " ")
+        end
+
+        def get_oidc_redirect_uri
+          @oidc_redirect_uri ||= ask_user(_("Redirect URI:%s") % " ")
+        end
+
+        def ask_user(prompt, silent=false)
+          if silent
+            HammerCLI.interactive_output.ask(prompt) { |q| q.echo = false }
+          else
+            HammerCLI.interactive_output.ask(prompt)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/api/oauth/password_grant.rb
+++ b/lib/hammer_cli_foreman/api/oauth/password_grant.rb
@@ -1,0 +1,81 @@
+require 'hammer_cli_foreman/openid_connect'
+
+module HammerCLIForeman
+  module Api
+    module Oauth
+      class PasswordGrant < ApipieBindings::Authenticators::TokenAuth
+        attr_accessor :oidc_token_endpoint, :oidc_client_id, :user, :password, :token
+
+        def initialize(oidc_token_endpoint, oidc_client_id, user, password)
+          @oidc_token_endpoint = oidc_token_endpoint
+          @oidc_client_id = oidc_client_id
+          @user = user
+          @password = password
+          super set_token(oidc_token_endpoint, oidc_client_id, user, password)
+        end
+
+        def authenticate(request, token)
+          if HammerCLI.interactive?
+            set_token_interactively
+          end
+          super
+        end
+
+        def set_token_interactively
+          @token ||= set_token(get_oidc_token_endpoint, get_oidc_client_id, get_user, get_password)
+        end
+
+        def set_token(input_oidc_token_endpoint, input_oidc_client_id, input_user, input_password)
+          @oidc_token_endpoint = input_oidc_token_endpoint if input_oidc_token_endpoint
+          @user = input_user
+          @password = input_password
+          @oidc_client_id = input_oidc_client_id if input_oidc_client_id
+          if @user && @password && @oidc_token_endpoint && @oidc_client_id
+            @token = HammerCLIForeman::OpenidConnect.new(
+              @oidc_token_endpoint, @oidc_client_id).get_token(@user, @password)
+          else
+            @token = nil
+          end
+        end
+
+        def error(ex)
+          if ex.is_a?(RestClient::InternalServerError)
+            @user = @password = @oidc_token_endpoint = @oidc_client_id = nil
+            original_message = _("Invalid credentials or oidc-client-id or oidc-token-endpoint.\n")
+            begin
+              message = JSON.parse(ex.response.body)['error']['message']
+            rescue
+            end
+            UnauthorizedError.new(original_message << message)
+          end
+        end
+
+        private
+
+        def get_user
+          @user ||= ask_user(_("Username:%s") % " ")
+        end
+
+        def get_password
+          @password ||= ask_user(_("Password:%{wsp}") % {:wsp => " "}, true)
+        end
+
+        def get_oidc_token_endpoint
+          @oidc_token_endpoint ||= ask_user(_("Openidc Provider Token Endpoint:%s") % " ")
+        end
+
+        def get_oidc_client_id
+          @oidc_client_id ||= ask_user(_("Client ID:%s") % " ")
+        end
+
+        def ask_user(prompt, silent=false)
+          if silent
+            HammerCLI.interactive_output.ask(prompt) { |q| q.echo = false }
+          else
+            HammerCLI.interactive_output.ask(prompt)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/authenticate/login.rb
+++ b/lib/hammer_cli_foreman/authenticate/login.rb
@@ -1,0 +1,21 @@
+module HammerCLIForeman
+  module Authenticate
+    module Login
+      def execute_with_params(auth_type, *args)
+        connection = HammerCLIForeman.foreman_api_reconnect(auth_type)
+        if !(connection.authenticator.is_a?(HammerCLIForeman::Api::SessionAuthenticatorWrapper))
+          HammerCLI.interactive_output.say(_("Can't perform login. Make sure sessions are enabled in hammer"\
+            " configuration file."))
+          return HammerCLI::EX_USAGE
+        end
+        connection.authenticator.set_auth_params(*args)
+        connection.authenticator.force_user_change
+        connection.login
+
+        HammerCLI.interactive_output.say(_("Successfully logged in as '%s'.") %
+          connection.authenticator.user)
+        HammerCLI::EX_OK
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/openid_connect.rb
+++ b/lib/hammer_cli_foreman/openid_connect.rb
@@ -1,0 +1,68 @@
+require 'net/http'
+require 'uri'
+module HammerCLIForeman
+  class OpenidConnect
+    def initialize(url, oidc_client_id)
+      @url = url
+      @oidc_client_id = oidc_client_id
+    end
+
+    def get_token(username, password)
+      uri = URI.parse(@url)
+      request = Net::HTTP::Post.new(uri)
+      request.content_type = 'application/x-www-form-urlencoded'
+      request.set_form_data(
+        'username' => username,
+        'password' => password,
+        'grant_type' => 'password',
+        'client_id' => @oidc_client_id
+      )
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |https|
+        https.request(request)
+      end
+      json_response = JSON.parse(response.body)
+      if json_response.is_a?(Hash)
+        json_response['access_token']
+      else
+        raise _("Invalid access token response.")
+        nil
+      end
+    rescue JSON::ParserError => e
+      raise _('Invalid access token')
+      nil
+    rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
+        Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+      raise _("Failed to recieve acess token, please check your connectivity with OpenID provider: %s") % e
+      nil
+    end
+
+    def get_token_via_2fa(code, oidc_redirect_uri)
+      uri = URI.parse(@url)
+      request = Net::HTTP::Post.new(uri)
+      request.content_type = 'application/x-www-form-urlencoded'
+      request.set_form_data(
+        'client_id' => @oidc_client_id,
+        'code' => code,
+        'grant_type' => 'authorization_code',
+        'redirect_uri' => oidc_redirect_uri
+      )
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |https|
+        https.request(request)
+      end
+      json_response = JSON.parse(response.body)
+      if json_response.is_a?(Hash)
+        json_response['access_token']
+      else
+        raise _("Invalid access token response.")
+        nil
+      end
+    rescue JSON::ParserError => e
+      raise _('Invalid access token')
+      nil
+    rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
+        Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+      raise _("Failed to recieve acess token, please check your connectivity with OpenID provider: %s") % e
+      nil
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/sessions.rb
+++ b/lib/hammer_cli_foreman/sessions.rb
@@ -1,0 +1,92 @@
+require 'uri'
+module HammerCLIForeman
+  class Sessions
+
+    STORAGE_DIR = File.expand_path('~/.hammer/sessions/')
+
+    def self.get(url)
+      raise _('Sessions are not enabled, please check your Hammer settings.') unless enabled?
+
+      unless File.exist?(storage)
+        FileUtils.mkdir_p(storage, mode: 0700)
+      end
+      unless configured?(url)
+        warn _('Using session auth with invalid permissions on session files is not recommended.')
+      end
+      HammerCLIForeman::Session.new(session_file(url))
+    end
+
+    def self.storage
+      STORAGE_DIR
+    end
+
+    def self.enabled?
+      HammerCLI::Settings.get(:foreman, :use_sessions)
+    end
+
+    def self.session_file(url)
+      raise _('The url is empty. Session can not be created.') if url.nil? || url.empty?
+
+      uri = URI.parse(url)
+      File.join(storage, "#{uri.scheme}_#{uri.host}")
+    rescue URI::InvalidURIError
+      raise _('The url (%s) is not a valid URL. Session can not be created.') % url
+    end
+
+    def self.configured?(url)
+      ensure_mode(storage, '40700') && ensure_mode(session_file(url), '100600')
+    end
+
+    def self.ensure_mode(file, expected_mode)
+      return true unless File.exist?(file)
+
+      mode = File.stat(file).mode.to_s(8)
+      if mode != expected_mode
+        warn _("Invalid permissions for %{file}: %{mode}, expected %{expected_mode}.") % {
+          :mode => mode,
+          :expected_mode => expected_mode,
+          :file => file
+        }
+        false
+      else
+        true
+      end
+    end
+  end
+
+  class Session
+    attr_accessor :id, :user_name, :auth_type
+
+    def initialize(session_path)
+      @session_path = File.expand_path(session_path)
+      if File.exist?(@session_path) && !File.zero?(@session_path)
+        session_data = JSON.parse(File.read(@session_path))
+        @id = session_data['id']
+        @user_name = session_data['user_name']
+        @auth_type = session_data['auth_type']
+      end
+    rescue JSON::ParserError
+      warn _('Invalid session data. Resetting the session.')
+    end
+
+    def store
+      File.open(@session_path,"w") do |f|
+        f.write({
+          id: id,
+          auth_type: auth_type,
+          user_name: user_name
+        }.to_json)
+      end
+      File.chmod(0600, @session_path)
+    end
+
+    def destroy
+      @id = nil
+      store
+    end
+
+    def valid?
+      !id.nil? && !id.empty?
+    end
+  end
+end

--- a/test/unit/api/interactive_basic_auth_test.rb
+++ b/test/unit/api/interactive_basic_auth_test.rb
@@ -43,7 +43,7 @@ describe HammerCLIForeman::Api::InteractiveBasicAuth do
   end
 
   context "non-interactive mode" do
-    it "desn't ask for credentials when tye're not provided" do
+    it "doesn't ask for credentials when they're not provided" do
       auth = HammerCLIForeman::Api::InteractiveBasicAuth.new(nil, nil)
       auth.expects(:ask_user).never
 

--- a/test/unit/api/oauth/oauth_authentication_code_grant_test.rb
+++ b/test/unit/api/oauth/oauth_authentication_code_grant_test.rb
@@ -1,0 +1,88 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe HammerCLIForeman::Api::Oauth::AuthenticationCodeGrant do
+  let(:request) { mock().stubs({}) }
+  let(:args) { {} }
+  let(:params) {{
+    oidc_redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+    oidc_token_endpoint: 'https://keycloak-server-url.example.com/token',
+    oidc_authorization_endpoint: 'https://keycloak-server-url.example.com/auth/',
+    oidc_client_id: 'hammer-cli-foreman'
+  }}
+
+  describe '#set_token' do
+    let(:auth) { HammerCLIForeman::Api::Oauth::AuthenticationCodeGrant.new(nil, nil, nil, nil) }
+
+    it 'sets token' do
+      auth.stubs(:get_code).returns('code')
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token_via_2fa).returns('token')
+      auth.set_token(params[:oidc_token_endpoint], params[:oidc_authorization_endpoint], params[:oidc_client_id], params[:oidc_redirect_uri])
+      assert_equal 'token', auth.token
+    end
+
+    it 'sets token as nil when all input parameter are missing' do
+      auth.stubs(:get_code).returns('code')
+      auth.set_token(nil, nil, nil, nil)
+      assert_equal nil, auth.token
+    end
+
+    it 'sets token as nil when any input parameter is missing' do
+      auth.stubs(:get_code).returns('code')
+      auth.set_token(nil, params[:oidc_authorization_endpoint], params[:oidc_client_id], params[:oidc_redirect_uri])
+      assert_equal nil, auth.token
+    end
+  end
+
+  context "interactive mode" do
+    before :each do
+      HammerCLI.stubs(:interactive?).returns true
+    end
+
+    it "asks for url, realm and oidc_client_id when nothing was provided" do
+      auth = HammerCLIForeman::Api::Oauth::AuthenticationCodeGrant.new(nil, nil, nil, nil)
+      auth.stubs(:ask_user).with('Openidc Provider Authorization Endpoint: ').returns(params[:oidc_authorization_endpoint])
+      auth.stubs(:ask_user).with('Openidc Provider Token Endpoint: ').returns(params[:oidc_token_endpoint])
+      auth.stubs(:ask_user).with('Client ID: ').returns(params[:oidc_client_id])
+      auth.stubs(:ask_user).with('Redirect URI: ').returns(params[:oidc_redirect_uri])
+      auth.stubs(:get_code).returns('code')
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token_via_2fa).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+
+    it "asks for the token endpoint when it wasn't provided" do
+      auth = HammerCLIForeman::Api::Oauth::AuthenticationCodeGrant.new(nil, params[:oidc_authorization_endpoint], params[:oidc_client_id], params[:oidc_redirect_uri])
+      auth.stubs(:ask_user).with('Openidc Provider Token Endpoint: ').returns(params[:oidc_token_endpoint])
+      auth.stubs(:get_code).returns('code')
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token_via_2fa).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+
+    it "asks for the authorization code endpoint when it wasn't provided" do
+      auth = HammerCLIForeman::Api::Oauth::AuthenticationCodeGrant.new(params[:oidc_token_endpoint], nil, params[:oidc_client_id], params[:oidc_redirect_uri])
+      auth.stubs(:ask_user).with('Openidc Provider Authorization Endpoint: ').returns(params[:oidc_authorization_endpoint])
+      auth.stubs(:get_code).returns('code')
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token_via_2fa).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+
+    it "asks for the url when url wasn't provided" do
+      auth = HammerCLIForeman::Api::Oauth::AuthenticationCodeGrant.new(params[:oidc_token_endpoint], params[:oidc_authorization_endpoint], nil, params[:oidc_redirect_uri])
+      auth.stubs(:ask_user).with('Client ID: ').returns(params[:oidc_client_id])
+      auth.stubs(:get_code).returns('code')
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token_via_2fa).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+  end
+end

--- a/test/unit/api/oauth/oauth_password_grant_test.rb
+++ b/test/unit/api/oauth/oauth_password_grant_test.rb
@@ -1,0 +1,92 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe HammerCLIForeman::Api::Oauth::PasswordGrant do
+  let(:request) { mock().stubs({}) }
+  let(:args) { {} }
+  let(:params) {{
+    username: 'user1',
+    password: 'password',
+    oidc_token_endpoint: 'https://keycloak-server-url.example.com/token',
+    oidc_client_id: 'hammer-cli-foreman'
+  }}
+
+  describe '#set_token' do
+    let(:auth) { HammerCLIForeman::Api::Oauth::PasswordGrant.new(nil, nil, nil, nil) }
+
+    it 'sets token' do
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token)
+        .with(params[:username], params[:password]).returns('token')
+      auth.set_token(params[:oidc_token_endpoint], params[:oidc_client_id], params[:username], params[:password])
+      assert_equal 'token', auth.token
+    end
+
+    it 'sets token as nil when all input parameter are missing' do
+      auth.set_token(nil, nil, nil, nil)
+      assert_equal nil, auth.token
+    end
+
+    it 'sets token as nil when any input parameter is missing' do
+      auth.set_token(nil, params[:oidc_client_id], params[:username], params[:password])
+      assert_equal nil, auth.token
+    end
+  end
+
+  context "interactive mode" do
+    before :each do
+      HammerCLI.stubs(:interactive?).returns true
+    end
+
+    it "asks for username, password, url, realm and oidc_client_id when nothing was provided" do
+      auth = HammerCLIForeman::Api::Oauth::PasswordGrant.new(nil, nil, nil, nil)
+      auth.stubs(:ask_user).with('Username: ').returns(params[:username])
+      auth.stubs(:ask_user).with('Password: ', true).returns(params[:password])
+      auth.stubs(:ask_user).with('Openidc Provider Token Endpoint: ').returns(params[:oidc_token_endpoint])
+      auth.stubs(:ask_user).with('Client ID: ').returns(params[:oidc_client_id])
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token).with(params[:username], params[:password]).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+
+    it "asks for the url when url wasn't provided" do
+      auth = HammerCLIForeman::Api::Oauth::PasswordGrant.new(nil, params[:oidc_client_id], params[:username], params[:password])
+      auth.stubs(:ask_user).with('Openidc Provider Token Endpoint: ').returns(params[:oidc_token_endpoint])
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token).with(params[:username], params[:password]).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+
+    it "asks for the oidc_client_id when oidc_client_id wasn't provided" do
+      auth = HammerCLIForeman::Api::Oauth::PasswordGrant.new(params[:oidc_token_endpoint], nil, params[:username], params[:password])
+      auth.stubs(:ask_user).with('Client ID: ').returns(params[:oidc_client_id])
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token).with(params[:username], params[:password]).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+
+    it "asks for the username when username wasn't provided" do
+      auth = HammerCLIForeman::Api::Oauth::PasswordGrant.new(params[:oidc_token_endpoint], params[:oidc_client_id], nil, params[:password])
+      auth.stubs(:ask_user).with('Username: ').returns(params[:username])
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token).with(params[:username], params[:password]).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+
+    it "asks for the password when password wasn't provided" do
+      auth = HammerCLIForeman::Api::Oauth::PasswordGrant.new(params[:oidc_token_endpoint], params[:oidc_client_id], params[:username], nil)
+      auth.stubs(:ask_user).with('Password: ', true).returns(params[:password])
+      HammerCLIForeman::OpenidConnect.any_instance.stubs(:get_token).with(params[:username], params[:password]).returns('token')
+      auth.authenticate(request, args)
+
+      assert_equal request.keys, ['Authorization']
+      assert_equal request.values, ['Bearer token']
+    end
+  end
+end

--- a/test/unit/sessions_test.rb
+++ b/test/unit/sessions_test.rb
@@ -1,0 +1,199 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'hammer_cli_foreman/sessions'
+require 'tmpdir'
+require 'tempfile'
+require 'json'
+
+describe HammerCLIForeman do
+  describe HammerCLIForeman::Sessions do
+    describe "#get" do
+      it 'should create session file when it doesn\'t exist' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(true)
+        Dir.mktmpdir do |dir|
+          HammerCLIForeman::Sessions.stubs(:storage).returns(dir)
+          session = HammerCLIForeman::Sessions.get('http://example.com')
+          session.id.must_be_nil
+          session.auth_type.must_be_nil
+          session.user_name.must_be_nil
+        end
+      end
+
+      it 'should load the session file' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(true)
+        Dir.mktmpdir do |dir|
+          HammerCLIForeman::Sessions.stubs(:storage).returns(dir)
+          session_content = {
+            :id => '3040b0f04c3a35a499e6837278904d48',
+            :user_name => 'admin',
+            :auth_type => 'basic_auth'
+          }
+          session_path = "#{dir}/http_example.com"
+          File.open(session_path,"w") do |f|
+            f.write(session_content.to_json)
+          end
+          File.chmod(0600, session_path)
+
+          session = HammerCLIForeman::Sessions.get('http://example.com')
+          session.id.must_equal '3040b0f04c3a35a499e6837278904d48'
+          session.auth_type.must_equal 'basic_auth'
+          session.user_name.must_equal 'admin'
+        end
+      end
+
+      it 'should create the storage dir if it does not exist' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(true)
+        Dir.mktmpdir do |dir|
+          HammerCLIForeman::Sessions.stubs(:storage).returns(dir)
+          FileUtils.rm_rf(dir)
+          HammerCLIForeman::Sessions.get('http://example.com')
+          File.exist?(dir).must_equal true
+        end
+      end
+
+      it 'should check permissions (700) on the storage' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(true)
+        Dir.mktmpdir do |dir|
+          HammerCLIForeman::Sessions.stubs(:storage).returns(dir)
+          FileUtils.chmod(0777, dir)
+          _, err = capture_io { HammerCLIForeman::Sessions.get('http://example.com') }
+          err.must_equal("Invalid permissions for #{dir}: 40777, expected 40700.\n" \
+              "Using session auth with invalid permissions on session files is not recommended.\n")
+        end
+      end
+
+      it 'should check permissions (600) on the storage file' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(true)
+        Dir.mktmpdir do |dir|
+          HammerCLIForeman::Sessions.stubs(:storage).returns(dir)
+          session_content = {
+            :id => '3040b0f04c3a35a499e6837278904d48',
+            :user_name => 'admin',
+            :auth_type => 'basic_auth'
+          }
+          session_path = "#{dir}/http_example.com"
+          File.open(session_path,"w") do |f|
+            f.write(session_content.to_json)
+          end
+          File.chmod(0666, session_path)
+
+          _, err = capture_io { HammerCLIForeman::Sessions.get('http://example.com') }
+          err.must_equal("Invalid permissions for #{session_path}: 100666, expected 100600.\n" \
+              "Using session auth with invalid permissions on session files is not recommended.\n")
+        end
+      end
+
+      it 'should fail if sessions are not enabled' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(false)
+        e = proc { HammerCLIForeman::Sessions.get('http://example.com')}.must_raise RuntimeError
+        e.message.must_equal "Sessions are not enabled, please check your Hammer settings."
+      end
+    end
+
+    describe "#enabled?" do
+      it 'tests sessions are enabled' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(true)
+        HammerCLIForeman::Sessions.enabled?.must_equal true
+      end
+
+      it 'tests sessions are disabled' do
+        HammerCLI::Settings.expects(:get).with(:foreman, :use_sessions).returns(false)
+        HammerCLIForeman::Sessions.enabled?.must_equal false
+      end
+    end
+
+    describe "#session_file" do
+      it 'should return file path for session' do
+        file_path = HammerCLIForeman::Sessions.session_file('http://example.com')
+        file_path.must_equal(File.join(HammerCLIForeman::Sessions.storage, 'http_example.com'))
+      end
+
+      it 'should handle invalid url' do
+        e = proc { HammerCLIForeman::Sessions.session_file('/\/')}.must_raise RuntimeError
+        e.message.must_equal "The url (/\\/) is not a valid URL. Session can not be created."
+      end
+
+      it 'should handle empty url' do
+        e = proc { HammerCLIForeman::Sessions.session_file('')}.must_raise RuntimeError
+        e.message.must_equal "The url is empty. Session can not be created."
+      end
+    end
+  end
+
+  describe HammerCLIForeman::Session do
+    it 'should be able to store its data' do
+      Tempfile.create('session') do |f|
+        session = HammerCLIForeman::Session.new(f.path)
+        session.id = '3040b0f04c3a35a499e6837278904d48'
+        session.auth_type = 'basic_auth'
+        session.user_name = 'admin'
+        session.store
+
+        session = HammerCLIForeman::Session.new(f.path)
+        session.id.must_equal '3040b0f04c3a35a499e6837278904d48'
+        session.auth_type.must_equal 'basic_auth'
+        session.user_name.must_equal 'admin'
+      end
+    end
+
+    it 'should store session file with 600 perm' do
+      Tempfile.create('session') do |f|
+        session = HammerCLIForeman::Session.new(f.path)
+        session.store
+        File.stat(f.path).mode.to_s(8).must_equal '100600'
+      end
+    end
+
+    it 'should reset invalid session file' do
+      Tempfile.create('session') do |f|
+        f << '{[Invalid'
+        f.rewind
+        _, err = capture_io do
+          session = HammerCLIForeman::Session.new(f.path)
+          session.id = nil
+          session.auth_type = nil
+          session.user_name = nil
+        end
+        err.must_equal("Invalid session data. Resetting the session.\n")
+      end
+    end
+
+    describe ".destroy" do
+      it 'should be able to destroy session' do
+        Tempfile.create('session') do |f|
+          session = HammerCLIForeman::Session.new(f.path)
+          session.id = '3040b0f04c3a35a499e6837278904d48'
+          session.auth_type = 'basic_auth'
+          session.user_name = 'admin'
+          session.destroy
+
+          session = HammerCLIForeman::Session.new(f.path)
+          session.id.must_be_nil
+          session.auth_type.must_equal 'basic_auth'
+          session.user_name.must_equal 'admin'
+        end
+      end
+    end
+
+    describe ".valid?" do
+      it "tests if session is invalid" do
+        Tempfile.create('session') do |f|
+          session = HammerCLIForeman::Session.new(f.path)
+          session.id = nil
+          session.auth_type = 'basic_auth'
+          session.user_name = 'admin'
+          session.valid?.must_equal false
+        end
+      end
+
+      it "tests if session is valid" do
+        Tempfile.create('session') do |f|
+          session = HammerCLIForeman::Session.new(f.path)
+          session.id = '34252624635723572357234'
+          session.auth_type = 'basic_auth'
+          session.user_name = 'admin'
+          session.valid?.must_equal true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
My attempt is to use keycloak for authenticating the user
and fetching the token, once we have the token we can send this
token to the foreman api, where we can use the `JWT` gem to
validate the token and then create a session for the user.

In this pr, I have attempted to fetch the token from keycloak using 
the rest-client gem. This token has to be passed to foreman where
it will be validated and accordingly authentication would be a success/failure.