### PR TITLE
Fixes #26099 - Add bootdisk back to params

### DIFF
--- a/lib/hammer_cli_foreman/hosts/common_update_options.rb
+++ b/lib/hammer_cli_foreman/hosts/common_update_options.rb
@@ -36,10 +36,12 @@ module HammerCLIForeman
           :format => HammerCLI::Options::Normalizers::KeyValueList.new
         base.option "--interface", "INTERFACE", _("Interface parameters"), :multivalued => true,
           :format => HammerCLI::Options::Normalizers::KeyValueList.new
+        base.option "--provision-method", "METHOD", " ",
+          :format => HammerCLI::Options::Normalizers::Enum.new(['build', 'image', 'bootdisk'])
 
         base.build_options :without => [
               # - temporarily disabled params that will be removed from the api ------------------
-              :capabilities, :flavour_ref, :image_ref, :start,
+              :provision_method, :capabilities, :flavour_ref, :image_ref, :start,
               :network, :cpus, :memory, :provider, :type, :tenant_id, :image_id,
               # ----------------------------------------------------------------------------------
               :puppet_class_ids, :host_parameters_attributes, :interfaces_attributes, :root_pass]


### PR DESCRIPTION
The pr that changed this has caused regression, I have used this for my fog-vsphere testing and @lzap is hitting this with a customer too. Opening a pr to revert the change. I have not seen any regression with this when doing testing etc.