### PR TITLE
Fixes #26234 - move compute resource validation to their class

### DIFF
--- a/lib/hammer_cli_foreman/compute_attribute.rb
+++ b/lib/hammer_cli_foreman/compute_attribute.rb
@@ -42,11 +42,10 @@ module HammerCLIForeman
 
       def request_params
         params = super
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"]
-        interfaces_attrs_name_list =  ::HammerCLIForeman.get_interfaces_list_name
-
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['compute_attribute']['vm_attrs'] = option_compute_attributes || {}
-        params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]]= HammerCLIForeman::ComputeAttribute.attribute_hash(option_interface_list) unless option_interface_list.empty?
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name]= HammerCLIForeman::ComputeAttribute.attribute_hash(option_interface_list) unless option_interface_list.empty?
         params['compute_attribute']['vm_attrs']['volumes_attributes'] = HammerCLIForeman::ComputeAttribute.attribute_hash(option_volume_list) unless option_volume_list.empty?
         params
       end
@@ -79,21 +78,21 @@ module HammerCLIForeman
       def request_params
 
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"]
-        interfaces_attrs_name_list =  ::HammerCLIForeman.get_interfaces_list_name
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
 
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
         params['id'] =  params['compute_attribute']['id']
         vm_attrs = params['compute_attribute']['vm_attrs']
         original_volumes = vm_attrs['volumes_attributes'] || {}
-        original_interfaces = vm_attrs[interfaces_attrs_name_list[compute_resource_name]] || {}
+        original_interfaces = vm_attrs[interfaces_attr_name] || {}
 
         if options['option_compute_attributes']
           vm_attrs = options['option_compute_attributes']
           vm_attrs['volumes_attributes'] ||= original_volumes
-          vm_attrs[interfaces_attrs_name_list[compute_resource_name]] ||= original_interfaces
+          vm_attrs[interfaces_attr_name] ||= original_interfaces
         end
-        vm_attrs[interfaces_attrs_name_list[compute_resource_name]] = HammerCLIForeman::ComputeAttribute.attribute_hash(options['option_interface_list']) unless options['option_interface_list'].empty?
+        vm_attrs[interfaces_attr_name] = HammerCLIForeman::ComputeAttribute.attribute_hash(options['option_interface_list']) unless options['option_interface_list'].empty?
         vm_attrs['volumes_attributes'] = HammerCLIForeman::ComputeAttribute.attribute_hash(options['option_volume_list']) unless options['option_volume_list'].empty?
         params['compute_attribute']['vm_attrs'] = vm_attrs
         params
@@ -126,17 +125,17 @@ module HammerCLIForeman
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
 
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"]
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
 
-        interfaces_attrs_name_list =  ::HammerCLIForeman.get_interfaces_list_name
 
-        interface_attr =  params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]] || {}
+        interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
+        interface_attr =  params['compute_attribute']['vm_attrs'][interfaces_attr_name] || {}
         new_interface_id = (interface_attr.keys.max.to_i + 1 ).to_s if interface_attr.any?
         new_interface_id ||= "0"
         params['id'] = params['compute_attribute']['id']
 
-        params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]] ||= {}
-        params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]][new_interface_id] = option_interface
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name] ||= {}
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name][new_interface_id] = option_interface
         params
       end
 
@@ -171,11 +170,11 @@ module HammerCLIForeman
       def request_params
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"]
-        interfaces_attrs_name_list =  ::HammerCLIForeman.get_interfaces_list_name
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['id'] = params['compute_attribute']['id']
-        params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]] ||= {}
-        params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]][option_interface_id] = option_interface
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name] ||= {}
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name][option_interface_id] = option_interface
         params
       end
       success_message _('Interface was updated.')
@@ -199,11 +198,11 @@ module HammerCLIForeman
       def request_params
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"]
-        interfaces_attrs_name_list =  ::HammerCLIForeman.get_interfaces_list_name
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['id'] = params['compute_attribute']['id']
-        if params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]].has_key?(option_interface_id.to_s)
-          params['compute_attribute']['vm_attrs'][interfaces_attrs_name_list[compute_resource_name]].delete(option_interface_id.to_s)
+        if params['compute_attribute']['vm_attrs'][interfaces_attr_name].has_key?(option_interface_id.to_s)
+          params['compute_attribute']['vm_attrs'][interfaces_attr_name].delete(option_interface_id.to_s)
         else
           signal_usage_error _('unknown interface id')
         end

--- a/lib/hammer_cli_foreman/compute_resource/base.rb
+++ b/lib/hammer_cli_foreman/compute_resource/base.rb
@@ -6,6 +6,7 @@ module HammerCLIForeman
       def interface_attributes; []; end
       def volume_attributes; []; end
       def interfaces_attrs_name; "interfaces_attributes" ; end
+      def mandatory_resource_options; [:name, :provider]; end
     end
   end
 end

--- a/lib/hammer_cli_foreman/compute_resource/ec2.rb
+++ b/lib/hammer_cli_foreman/compute_resource/ec2.rb
@@ -14,7 +14,11 @@ module HammerCLIForeman
             'managed_ip'
         ]
       end
+
+      def mandatory_resource_options
+        super + [:region, :user, :password]
+      end
     end
-    HammerCLIForeman.register_compute_resource('EC2', EC2.new )
+    HammerCLIForeman.register_compute_resource('ec2', EC2.new )
   end
 end

--- a/lib/hammer_cli_foreman/compute_resource/gce.rb
+++ b/lib/hammer_cli_foreman/compute_resource/gce.rb
@@ -18,6 +18,6 @@ module HammerCLIForeman
         "network_interfaces_nics_attributes"
       end
     end
-    HammerCLIForeman.register_compute_resource('GCE', GCE.new)
+    HammerCLIForeman.register_compute_resource('gce', GCE.new)
   end
 end

--- a/lib/hammer_cli_foreman/compute_resource/libvirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/libvirt.rb
@@ -38,7 +38,12 @@ module HammerCLIForeman
       def interfaces_attrs_name
         "nics_attributes"
       end
+
+      def mandatory_resource_options
+        super + [:url]
+      end
+
     end
-    HammerCLIForeman.register_compute_resource('Libvirt', Libvirt.new)
+    HammerCLIForeman.register_compute_resource('libvirt', Libvirt.new)
   end
 end

--- a/lib/hammer_cli_foreman/compute_resource/openstack.rb
+++ b/lib/hammer_cli_foreman/compute_resource/openstack.rb
@@ -14,7 +14,12 @@ module HammerCLIForeman
             'network'
         ]
       end
+
+      def mandatory_resource_options
+        super + [:url, :user, :password]
+      end
+
     end
-    HammerCLIForeman.register_compute_resource('OpenStack', OpenStack.new)
+    HammerCLIForeman.register_compute_resource('openstack', OpenStack.new)
   end
 end

--- a/lib/hammer_cli_foreman/compute_resource/ovirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/ovirt.rb
@@ -36,7 +36,12 @@ module HammerCLIForeman
             ['bootable',       _('Boolean, only one volume can be bootable')]
         ]
       end
+
+      def mandatory_resource_options
+        super + [:url, :user, :password, :datacenter]
+      end
+
     end
-    HammerCLIForeman.register_compute_resource('oVirt', Ovirt.new)
+    HammerCLIForeman.register_compute_resource('ovirt', Ovirt.new)
   end
 end

--- a/lib/hammer_cli_foreman/compute_resource/rackspace.rb
+++ b/lib/hammer_cli_foreman/compute_resource/rackspace.rb
@@ -11,7 +11,12 @@ module HammerCLIForeman
             'image_id'
         ]
       end
+
+      def mandatory_resource_options
+        super + [:url]
+      end
+
     end
-    HammerCLIForeman.register_compute_resource('Rackspace', Rackspace.new)
+    HammerCLIForeman.register_compute_resource('rackspace', Rackspace.new)
   end
 end

--- a/lib/hammer_cli_foreman/compute_resource/register_compute_resources.rb
+++ b/lib/hammer_cli_foreman/compute_resource/register_compute_resources.rb
@@ -1,18 +1,14 @@
 module HammerCLIForeman
   @compute_resources = {}
-  @interfaces_attrs_name_list ={}
   def self.compute_resources
     @compute_resources
   end
 
   def self.register_compute_resource(name, compute_resource)
     @compute_resources[name] = compute_resource
-    @interfaces_attrs_name_list[name] = compute_resource.interfaces_attrs_name
   end
 
-  def self.get_interfaces_list_name
-    @interfaces_attrs_name_list
-  end
+
   require 'hammer_cli_foreman/compute_resource/base'
   require 'hammer_cli_foreman/compute_resource/ec2.rb'
   require 'hammer_cli_foreman/compute_resource/gce.rb'

--- a/lib/hammer_cli_foreman/compute_resource/vmware.rb
+++ b/lib/hammer_cli_foreman/compute_resource/vmware.rb
@@ -57,7 +57,12 @@ module HammerCLIForeman
             ['mode',        'persistent/independent_persistent/independent_nonpersistent']
         ]
       end
+
+      def mandatory_resource_options
+          super + [:user, :password, :datacenter, :server]
+
+      end
     end
-    HammerCLIForeman.register_compute_resource('VMware', VMware.new)
+    HammerCLIForeman.register_compute_resource('vmware', VMware.new)
   end
 end

--- a/test/functional/compute_resource_test.rb
+++ b/test/functional/compute_resource_test.rb
@@ -39,10 +39,9 @@ describe 'compute-resource' do
     end
 
     it 'should print error for incorrect/invalid --provider option' do
-      params = %w(--provider=unknown)
-
+      params = %w(--provider=unknown --name=new)
       expected_result = CommandExpectation.new
-      expected_result.expected_err = options_missing_error
+      expected_result.expected_err = "Could not create the compute resource:\n  incorrect/invalid --provider option\n"
       expected_result.expected_exit_code = HammerCLI::EX_USAGE
 
       api_expects_no_call
@@ -53,12 +52,10 @@ describe 'compute-resource' do
     end
 
     it 'should print error for blank --provider option' do
-      params = %w(--provider='')
-
+      params = %w(--provider= --name=new'')
       expected_result = CommandExpectation.new
-      expected_result.expected_err = options_missing_error
+      expected_result.expected_err = "Could not create the compute resource:\n  incorrect/invalid --provider option\n"
       expected_result.expected_exit_code = HammerCLI::EX_USAGE
-
       api_expects_no_call
 
       result = run_cmd(@cmd + params)


### PR DESCRIPTION
This PR includes: 
- Changing the validation in case of creating a new compute resource to their class, which makes the registration of each compute resource very easy.
-  Changing the compute resource name to lower case letter
- Remove interfaces_attrs_name_list helper method in HammerCLIForeman 