### PR TITLE
Fixes #26355 - background template rendering

### DIFF
--- a/lib/hammer_cli_foreman/report_template.rb
+++ b/lib/hammer_cli_foreman/report_template.rb
@@ -98,9 +98,9 @@ module HammerCLIForeman
         if option_wait?
           poll_for_report(data)
         else
-          puts data['job_id']
-          HammerCLI::EX_OK
+          print_message(_('The report has been scheduled. Job ID: %{job_id}') % { job_id: data['job_id'] })
         end
+        HammerCLI::EX_OK
       end
 
       build_options
@@ -140,20 +140,19 @@ module HammerCLIForeman
         response = send_request
         if response.code == 204
           print_message(_('The report is not ready yet.'))
-          return HammerCLI::EX_OK
         else
           handle_success(response)
         end
+        HammerCLI::EX_OK
       end
 
       def handle_success(response)
         if option_path
           filepath = store_response(response)
-          print_message(_('The response has been saved to %{path}s.'), {:path => filepath})
+          print_message(_('The response has been saved to %{path}.'), {:path => filepath})
         else
           puts response.body
         end
-        return HammerCLI::EX_OK
       end
     end
 

--- a/lib/hammer_cli_foreman/report_template.rb
+++ b/lib/hammer_cli_foreman/report_template.rb
@@ -140,10 +140,11 @@ module HammerCLIForeman
         response = send_request
         if response.code == 204
           print_message(_('The report is not ready yet.'))
+          HammerCLI::EX_TEMPFAIL
         else
           handle_success(response)
+          HammerCLI::EX_OK
         end
-        HammerCLI::EX_OK
       end
 
       def handle_success(response)

--- a/test/functional/report_template_test.rb
+++ b/test/functional/report_template_test.rb
@@ -346,7 +346,7 @@ describe 'report-template' do
         'id' => '3', 'job_id' => 'JOB-UNIQUE-ID').returns(report_not_ready_response)
 
       output = OutputMatcher.new("The report is not ready yet.")
-      expected_result = success_result(output)
+      expected_result = CommandExpectation.new(output, '', HammerCLI::EX_TEMPFAIL)
       result = run_cmd(cmd + params)
       assert_cmd(expected_result, result)
     end


### PR DESCRIPTION
I have added scheduling, so you can schedule report and download it once it is ready through second command.

The `schedule` command has `--wait` option, which will wait for the result actively.