### PR TITLE
Fixes #27094 - hammer host list including errata info

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -29,6 +29,17 @@ module HammerCLIForeman
         field :global_status_label, _("Global Status")
         field nil, _("Organization"), Fields::SingleReference, :key => :organization, :hide_blank => true, :sets => ['ALL']
         field nil, _("Location"), Fields::SingleReference, :key => :location, :hide_blank => true, :sets => ['ALL']
+        from :content_facet_attributes do
+          from :errata_counts do
+            field :security, _("Security")
+          end
+          from :errata_counts do
+            field :bugfix, _("Bugfix")
+          end
+          from :errata_counts do
+            field :enhancement, _("Enhancement")
+          end
+        end
         field :comment, _("Additional Information"), nil, :sets => ['ALL']
       end
 


### PR DESCRIPTION
The customer will be able to see via `hammer host list` information about errata
```
# hammer host list
-----|-----------------------------|------------------|--------------------------------------------------|----------------|-------------------|----------|--------|-------------|---------------------------|----------------------
ID   | NAME                        | OPERATING SYSTEM | HOST GROUP                                       | IP             | MAC               | SECURITY | BUGFIX | ENHANCEMENT | CONTENT VIEW              | LIFECYCLE ENVIRONMENT
-----|-----------------------------|------------------|--------------------------------------------------|----------------|-------------------|----------|--------|-------------|---------------------------|----------------------
58   | aldrey.local.domain         | RHEL Server 7.6  |                                                  | 192.168.56.215 | 52:54:00:41:ed:5e | 0        | 0      | 0           | Default Organization View | Library              
1049 | angie-molyneux.local.domain | RHEL Server 7.4  | hg_prov_rhel74/hg_prov_rhel74_with_puppet        | 192.168.56.222 | 52:54:00:08:2d:73 | 0        | 0      | 0           | Default Organization View | Library              
1052 | benny-mangen.local.domain   | RHEL Server 7.4  | hg_prov_rhel74/hg_prov_rhel74_with_ansible_roles | 192.168.56.203 | 52:54:00:6b:bc:d0 | 65       | 240    | 39          | Default Organization View | Library              
1047 | bryce-hatstat.local.domain  | RHEL Server 7.4  | hg_prov_rhel74/hg_prov_rhel74_with_ansible_roles | 192.168.56.236 | 52:54:00:85:df:8a | 65       | 240    | 39          | Default Organization View | Library 
```