### PR TITLE
Fixes #25584 - Improve help for compute resources

### DIFF
--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -175,17 +175,16 @@ Provider specific options
 Available keys for `--compute-attributes`:
 ```
 flavor_id          # select one of available flavours
-image_id           # select one of available images
 availability_zone
 security_group_ids
 managed_ip
+groups
 ```
 
 ## GCE
 Available keys for `--compute-attributes`:
 ```
 machine_type # one of available flavors
-image_id
 network
 associate_external_ip
 ```
@@ -195,6 +194,7 @@ Available keys for `--compute-attributes`:
 ```
 cpus          # number of CPUs
 memory        # string, amount of memory, value in bytes
+cpu_mode      # possible values: default, host-model, host-passthrough
 start         # Must be a 1 or 0, whether to start the machine or not
 ```
 
@@ -208,13 +208,16 @@ compute_model                     # one of [virtio, rtl8139, ne2k_pci, pcnet, e1
 Available keys for `--volume`:
 ```
 pool_name   # list of available storage pools
-capacity    # string value, eg. 10G
+capacity    # string value, e.g. 10G
 format_type # one of [raw, qcow2]
+allocation  # initial allocation, e.g. 0G
 ```
 
 ## OpenStack
 Available keys for `--compute-attributes`:
 ```
+availability_zone
+boot_from_volume
 flavor_ref
 image_ref
 tenant_id
@@ -228,6 +231,7 @@ Available keys for `--compute-attributes`:
 cluster
 template   # hardware profile to use
 cores      # int value, number of cores
+sockets    # int value, number of sockets
 memory     # amount of memory, int value in bytes
 start      # Must be a 1 or 0, whether to start the machine or not
 ```
@@ -236,6 +240,7 @@ Available keys for `--interface`:
 ```
 compute_name         # eg. eth0
 compute_network      # select one of available networks for a cluster
+compute_interface    # interface type
 ```
 
 Available keys for `--volume`:
@@ -251,7 +256,6 @@ wipe_after_delete  # boolean, set true to wipe disk after delete
 Available keys for `--compute-attributes`:
 ```
 flavor_id
-image_id
 ```
 
 ## VMware
@@ -265,13 +269,15 @@ cluster               Cluster ID from VMware
 resource_pool         Resource Pool ID from VMware
 path                  Path to folder
 guest_id              Guest OS ID form VMware
-scsi_controller_type  ID of the controller from VMware
 hardware_version      Hardware version ID from VMware
 add_cdrom             Must be a 1 or 0, Add a CD-ROM drive to the virtual machine
 cpuHotAddEnabled      Must be a 1 or 0, lets you add memory resources while the machine is on
-memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on
-start                 Must be a 1 or 0, whether to start the machine or not
+memoryHotAddEnabled   Must be a 1 or 0, lets you add CPU resources while the machine is on the machine or not
 annotation            Annotation Notes
+scsi_controllers      List with SCSI controllers definitions
+                        type - ID of the controller from VMware
+                        key  - Key of the controller (e.g. 1000)
+start         # Must be a 1 or 0, whether to start the machine or not
 ```
 
 Available keys for `--interface`:
@@ -294,4 +300,5 @@ size_gb             Integer number, volume size in GB
 thin                true/false
 eager_zero          true/false
 mode                persistent/independent_persistent/independent_nonpersistent
+controller_key      Associated SCSI controller key
 ```

--- a/lib/hammer_cli_foreman/command_extensions/hosts/help/compute_resources.rb
+++ b/lib/hammer_cli_foreman/command_extensions/hosts/help/compute_resources.rb
@@ -44,6 +44,7 @@ module HammerCLIForeman
               @help_block ||= Proc.new do
                 help do |h|
                   h.section(_('Provider specific options')) do |h|
+                    h.note(_('Bold attributes are required.'), richtext: true)
                     HammerCLIForeman.compute_resources.each do |name, provider|
                       next unless current_providers.include?(name)
 

--- a/lib/hammer_cli_foreman/compute_resource/ec2.rb
+++ b/lib/hammer_cli_foreman/compute_resource/ec2.rb
@@ -6,7 +6,7 @@ module HammerCLIForeman
       end
 
       def compute_attributes
-        %w[flavor_id image_id availability_zone security_group_ids managed_ip]
+        %w[availability_zone flavor_id groups security_group_ids managed_ip]
       end
 
       def provider_specific_fields

--- a/lib/hammer_cli_foreman/compute_resource/gce.rb
+++ b/lib/hammer_cli_foreman/compute_resource/gce.rb
@@ -6,7 +6,7 @@ module HammerCLIForeman
       end
 
       def compute_attributes
-        %w[machine_type image_id network associate_external_ip]
+        %w[machine_type network associate_external_ip]
       end
 
       def interfaces_attrs_name

--- a/lib/hammer_cli_foreman/compute_resource/libvirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/libvirt.rb
@@ -7,14 +7,15 @@ module HammerCLIForeman
 
       def compute_attributes
         [
-          ['cpus',   _('Number of CPUs')],
-          ['memory', _('String, amount of memory, value in bytes')]
+          ['cpus',   _('Number of CPUs'), { bold: true }],
+          ['memory', _('String, amount of memory, value in bytes'), { bold: true }],
+          ['cpu_mode', _('Possible values: %{modes}') % { modes: 'default, host-model, host-passthrough' }]
         ]
       end
 
       def host_attributes
         [
-          ['start',  _('Boolean (expressed as 0 or 1), whether to start the machine or not')]
+          ['start', _('Boolean (expressed as 0 or 1), whether to start the machine or not')]
         ]
       end
 
@@ -22,14 +23,16 @@ module HammerCLIForeman
         [
           ['compute_type',   _('Possible values: %s') % 'bridge, network'],
           ['compute_bridge', _('Name of interface according to type')],
-          ['compute_model',  _('Possible values: %s') % 'virtio, rtl8139, ne2k_pci, pcnet, e1000']
+          ['compute_model',  _('Possible values: %s') % 'virtio, rtl8139, ne2k_pci, pcnet, e1000'],
+          ['compute_network'], _('Libvirt instance network, e.g. default')
         ]
       end
 
       def volume_attributes
         [
-          ['pool_name',   _('One of available storage pools')],
-          ['capacity',    _('String value, eg. 10G')],
+          ['pool_name',   _('One of available storage pools'), { bold: true }],
+          ['capacity',    _('String value, e.g. 10G'), { bold: true }],
+          ['allocation'], _('Initial allocation, e.g. 0G'),
           ['format_type', _('Possible values: %s') % 'raw, qcow2']
         ]
       end

--- a/lib/hammer_cli_foreman/compute_resource/openstack.rb
+++ b/lib/hammer_cli_foreman/compute_resource/openstack.rb
@@ -6,7 +6,7 @@ module HammerCLIForeman
       end
 
       def compute_attributes
-        %w[flavor_ref image_ref tenant_id security_groups network]
+        %w[availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network]
       end
 
       def provider_specific_fields

--- a/lib/hammer_cli_foreman/compute_resource/ovirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/ovirt.rb
@@ -10,6 +10,7 @@ module HammerCLIForeman
           ['cluster',  _('ID of cluster to use')],
           ['template', _('Hardware profile to use')],
           ['cores',    _('Integer value, number of cores')],
+          ['sockets',  _('Integer value, number of sockets')],
           ['memory',   _('Amount of memory, integer value in bytes')]
         ]
       end

--- a/lib/hammer_cli_foreman/compute_resource/rackspace.rb
+++ b/lib/hammer_cli_foreman/compute_resource/rackspace.rb
@@ -6,7 +6,7 @@ module HammerCLIForeman
       end
 
       def compute_attributes
-        %w[flavor_id image_id]
+        %w[flavor_id]
       end
 
       def provider_specific_fields

--- a/lib/hammer_cli_foreman/compute_resource/vmware.rb
+++ b/lib/hammer_cli_foreman/compute_resource/vmware.rb
@@ -9,13 +9,13 @@ module HammerCLIForeman
 
       def compute_attributes
         [
-          ['cpus',                 _('CPU count')],
-          ['corespersocket',       _('Number of cores per socket (applicable to hardware versions < 10 only)')],
-          ['memory_mb',            _('Integer number, amount of memory in MB')],
+          ['cluster',              _('Cluster ID from VMware'), { bold: true }],
+          ['corespersocket',       _('Number of cores per socket (applicable to hardware versions < 10 only)'), { bold: true }],
+          ['cpus',                 _('CPU count'), { bold: true }],
+          ['memory_mb',            _('Integer number, amount of memory in MB'), { bold: true }],
+          ['path',                 _('Path to folder'), { bold: true }],
+          ['resource_pool',        _('Resource Pool ID from VMware'), { bold: true }],
           ['firmware',             'automatic/bios/efi'],
-          ['cluster',              _('Cluster ID from VMware')],
-          ['resource_pool',        _('Resource Pool ID from VMware')],
-          ['path',                 _('Path to folder')],
           ['guest_id',             _('Guest OS ID form VMware')],
           ['hardware_version',     _('Hardware version ID from VMware')],
           ['memoryHotAddEnabled',  _('Must be a 1 or 0, lets you add CPU resources while the machine is on')],


### PR DESCRIPTION
The issue actually is about showing unclear errors, but since the error (e.g. mentioned in the issue) comes from the server, I'd say it is a server side issue.

What I'm proposing is to improve help section for CR in host creation help. Particularly to emphasize which attributes are required (e.g. `path` mentioned in the issue). Unfortunatelly I've got no environment (except libvirt and a dummy created from VMware) to test which attributes are really required. The chages are based on UI and [CR models](https://github.com/theforeman/foreman/tree/develop/app/models/compute_resources/foreman/model) (basically on `default_vm_attributes`/`new_vm`/`create_vm`, etc)

Requires https://github.com/theforeman/hammer-cli/pull/309 to be merged first. Also this PR is built above https://github.com/theforeman/hammer-cli-foreman/pull/424, since there are chages which will lead to merge conflicts.