### PR TITLE
Fixes #27323 - Update environments options for puppet context

### DIFF
--- a/lib/hammer_cli_foreman/combination.rb
+++ b/lib/hammer_cli_foreman/combination.rb
@@ -32,6 +32,8 @@ module HammerCLIForeman
         o.expand(:all).except(:config_templates,)
         o.without(:config_template_id)
       end
+
+      extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironment.new)
     end
 
     class ListCombination < HammerCLIForeman::ListCommand

--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -31,6 +31,8 @@ module HammerCLIForeman
       end
 
       build_options :without => [:include]
+
+      extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironment.new)
     end
 
 

--- a/lib/hammer_cli_foreman/location.rb
+++ b/lib/hammer_cli_foreman/location.rb
@@ -56,6 +56,8 @@ module HammerCLIForeman
       failure_message _("Could not create the location")
 
       build_options
+
+      extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironments.new)
     end
 
 
@@ -68,6 +70,8 @@ module HammerCLIForeman
       failure_message _("Could not update the location")
 
       build_options
+
+      extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironments.new)
     end
 
 

--- a/lib/hammer_cli_foreman/puppet_class.rb
+++ b/lib/hammer_cli_foreman/puppet_class.rb
@@ -26,6 +26,8 @@ module HammerCLIForeman
       end
 
       build_options
+
+      extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironment.new)
     end
 
 
@@ -44,6 +46,8 @@ module HammerCLIForeman
       end
 
       build_options
+
+      extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironment.new)
     end
 
 
@@ -70,6 +74,3 @@ module HammerCLIForeman
   end
 
 end
-
-
-


### PR DESCRIPTION
Related to https://github.com/theforeman/hammer-cli-foreman/pull/401. Some currently deprecated `--enviornment` options weren't added to the mentioned fix.