### PR TITLE
Fixes #27339 - Report template schedule works with --name

### DIFF
--- a/lib/hammer_cli_foreman/report_template.rb
+++ b/lib/hammer_cli_foreman/report_template.rb
@@ -123,7 +123,7 @@ module HammerCLIForeman
 
       def build_report_data_args(schedule_data)
         [
-          '--id', option_id,
+          '--id', options['option_id'],
           '--job-id', schedule_data['job_id'],
           '--path', option_path
         ]


### PR DESCRIPTION
When a user specifies `--name` option it is automatically resolved into `id` and saved into `options` under `option_id` key. The `option_id` method can be used only when a user has explicitly specified it. That caused the issue.