### PR TITLE
Fixes #27343 - consider value not display name of compute_resource

### DIFF
--- a/lib/hammer_cli_foreman/compute_attribute.rb
+++ b/lib/hammer_cli_foreman/compute_attribute.rb
@@ -1,5 +1,6 @@
-require 'hammer_cli_foreman/image'
 require 'hammer_cli_foreman/compute_resource/register_compute_resources'
+require 'hammer_cli_foreman/compute_resource/utils'
+require 'hammer_cli_foreman/image'
 
 module HammerCLIForeman
   class ComputeAttribute < HammerCLIForeman::Command
@@ -37,7 +38,7 @@ module HammerCLIForeman
 
       def request_params
         params = super
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
+        compute_resource_name = HammerCLIForeman::ComputeResources.resource_provider(options['option_compute_resource_id'])
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['compute_attribute']['vm_attrs'] = option_compute_attributes || {}
         params['compute_attribute']['vm_attrs'][interfaces_attr_name]= HammerCLIForeman::ComputeAttribute.attribute_hash(option_interface_list) unless option_interface_list.empty?
@@ -70,7 +71,7 @@ module HammerCLIForeman
       def request_params
 
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
+        compute_resource_name = HammerCLIForeman::ComputeResources.resource_provider(options['option_compute_resource_id'])
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
 
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
@@ -115,9 +116,7 @@ module HammerCLIForeman
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
 
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
-
-
+        compute_resource_name = HammerCLIForeman::ComputeResources.resource_provider(options['option_compute_resource_id'])
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         interface_attr =  params['compute_attribute']['vm_attrs'][interfaces_attr_name] || {}
         new_interface_id = (interface_attr.keys.max.to_i + 1 ).to_s if interface_attr.any?
@@ -158,7 +157,7 @@ module HammerCLIForeman
       def request_params
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
+        compute_resource_name = HammerCLIForeman::ComputeResources.resource_provider(options['option_compute_resource_id'])
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['id'] = params['compute_attribute']['id']
         params['compute_attribute']['vm_attrs'][interfaces_attr_name] ||= {}
@@ -188,7 +187,7 @@ module HammerCLIForeman
       def request_params
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
+        compute_resource_name = HammerCLIForeman::ComputeResources.resource_provider(options['option_compute_resource_id'])
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['id'] = params['compute_attribute']['id']
         if params['compute_attribute']['vm_attrs'][interfaces_attr_name].has_key?(option_interface_id.to_s)

--- a/lib/hammer_cli_foreman/compute_attribute.rb
+++ b/lib/hammer_cli_foreman/compute_attribute.rb
@@ -37,7 +37,7 @@ module HammerCLIForeman
 
       def request_params
         params = super
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['compute_attribute']['vm_attrs'] = option_compute_attributes || {}
         params['compute_attribute']['vm_attrs'][interfaces_attr_name]= HammerCLIForeman::ComputeAttribute.attribute_hash(option_interface_list) unless option_interface_list.empty?
@@ -70,7 +70,7 @@ module HammerCLIForeman
       def request_params
 
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
 
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
@@ -115,7 +115,7 @@ module HammerCLIForeman
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
 
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
 
 
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
@@ -158,7 +158,7 @@ module HammerCLIForeman
       def request_params
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['id'] = params['compute_attribute']['id']
         params['compute_attribute']['vm_attrs'][interfaces_attr_name] ||= {}
@@ -188,7 +188,7 @@ module HammerCLIForeman
       def request_params
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
         raise ArgumentError, "Compute profile value to update does not exist yet; it needs to be created first" if !params['compute_attribute'].key?('id')
-        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider_friendly_name"].downcase
+        compute_resource_name = HammerCLIForeman.record_to_common_format(HammerCLIForeman.foreman_resource(:compute_resources).call(:show, 'id' => options["option_compute_resource_id"] ))["provider"].downcase
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['id'] = params['compute_attribute']['id']
         if params['compute_attribute']['vm_attrs'][interfaces_attr_name].has_key?(option_interface_id.to_s)

--- a/lib/hammer_cli_foreman/compute_resource/utils.rb
+++ b/lib/hammer_cli_foreman/compute_resource/utils.rb
@@ -15,5 +15,13 @@ module HammerCLIForeman
         )['compute_resource_id']
       )
     end
+
+    def self.resource_provider(compute_resource_id)
+      HammerCLIForeman.record_to_common_format(
+        HammerCLIForeman.foreman_resource(:compute_resources).call(
+          :show, 'id' => compute_resource_id
+        )
+      )['provider'].downcase
+    end
   end
 end


### PR DESCRIPTION
adding @shiramax and @ezr-ondrej into the loop

Provider friendly name of GCE compute resource is `Google` so compute attribute flow is broken for GCE.