### PR TITLE
Fixes #27375 - remove duplicate options from host update

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -311,7 +311,6 @@ module HammerCLIForeman
 
       success_message _("Host updated.")
       failure_message _("Could not update the host")
-      include HammerCLIForeman::Hosts::CommonUpdateOptions
 
       extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironment.new)
       extend_with(HammerCLIForeman::CommandExtensions::Hosts::Help::Interfaces.new)


### PR DESCRIPTION
In one of the merged PRs the option include was moved to new place but not removed from its original position. This PR is fixing the state