### PR TITLE
Fixes #23204 - Consistent puppet environment naming in hammer

### DIFF
--- a/lib/hammer_cli_foreman/command_extensions.rb
+++ b/lib/hammer_cli_foreman/command_extensions.rb
@@ -1,3 +1,6 @@
 require 'hammer_cli_foreman/command_extensions/puppet_environment'
+require 'hammer_cli_foreman/command_extensions/puppet_environment'
+require 'hammer_cli_foreman/command_extensions/puppet_environments'
+require 'hammer_cli_foreman/command_extensions/option_sources'
 require 'hammer_cli_foreman/command_extensions/puppet_environments'
 require 'hammer_cli_foreman/command_extensions/option_sources'


### PR DESCRIPTION
(cherry picked from commit 1862075e302144527bcd10845624b881fc438bc1)