### PR TITLE
Fixes #27652 - Fix interfaces when creating a host

### DIFF
--- a/lib/hammer_cli_foreman/compute_attribute.rb
+++ b/lib/hammer_cli_foreman/compute_attribute.rb
@@ -21,6 +21,22 @@ module HammerCLIForeman
       attribute_list.size.times.map { |idx| idx.to_s }.zip(attribute_list).to_h
     end
 
+    def self.alter_interface(interface)
+      # move each attribute starting with "compute_" to compute_attributes
+        interface.keys.each do |key|
+          if key.start_with? 'compute_'
+            interface[key.gsub('compute_', '')] = interface.delete(key)
+          end
+        end
+        interface
+    end
+
+    def self.alter_interfaces_list(interfaces_list)
+      interfaces_list.collect do |nic|
+        alter_interface(nic)
+      end
+    end
+
     class Create < HammerCLIForeman::CreateCommand
       desc _('Create compute profile set of values')
 
@@ -41,7 +57,8 @@ module HammerCLIForeman
         compute_resource_name = HammerCLIForeman::ComputeResources.resource_provider(options['option_compute_resource_id'])
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['compute_attribute']['vm_attrs'] = option_compute_attributes || {}
-        params['compute_attribute']['vm_attrs'][interfaces_attr_name]= HammerCLIForeman::ComputeAttribute.attribute_hash(option_interface_list) unless option_interface_list.empty?
+        interfaces_list = HammerCLIForeman::ComputeAttribute.alter_interfaces_list(options['option_interface_list']) unless options['option_interface_list'].empty?
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name]= HammerCLIForeman::ComputeAttribute.attribute_hash(interfaces_list) if interfaces_list
         params['compute_attribute']['vm_attrs']['volumes_attributes'] = HammerCLIForeman::ComputeAttribute.attribute_hash(option_volume_list) unless option_volume_list.empty?
         params
       end
@@ -69,7 +86,6 @@ module HammerCLIForeman
       end
 
       def request_params
-
         params = HammerCLIForeman::ComputeAttribute.get_params(options)
         compute_resource_name = HammerCLIForeman::ComputeResources.resource_provider(options['option_compute_resource_id'])
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
@@ -85,7 +101,8 @@ module HammerCLIForeman
           vm_attrs['volumes_attributes'] ||= original_volumes
           vm_attrs[interfaces_attr_name] ||= original_interfaces
         end
-        vm_attrs[interfaces_attr_name] = HammerCLIForeman::ComputeAttribute.attribute_hash(options['option_interface_list']) unless options['option_interface_list'].empty?
+        interfaces_list = HammerCLIForeman::ComputeAttribute.alter_interfaces_list(options['option_interface_list']) unless options['option_interface_list'].empty?
+        vm_attrs[interfaces_attr_name] = HammerCLIForeman::ComputeAttribute.attribute_hash(interfaces_list) if interfaces_list
         vm_attrs['volumes_attributes'] = HammerCLIForeman::ComputeAttribute.attribute_hash(options['option_volume_list']) unless options['option_volume_list'].empty?
         params['compute_attribute']['vm_attrs'] = vm_attrs
         params
@@ -124,7 +141,7 @@ module HammerCLIForeman
         params['id'] = params['compute_attribute']['id']
 
         params['compute_attribute']['vm_attrs'][interfaces_attr_name] ||= {}
-        params['compute_attribute']['vm_attrs'][interfaces_attr_name][new_interface_id] = option_interface
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name][new_interface_id] = HammerCLIForeman::ComputeAttribute.alter_interface(option_interface)
         params
       end
 
@@ -161,7 +178,7 @@ module HammerCLIForeman
         interfaces_attr_name = ::HammerCLIForeman.compute_resources[compute_resource_name].interfaces_attrs_name
         params['id'] = params['compute_attribute']['id']
         params['compute_attribute']['vm_attrs'][interfaces_attr_name] ||= {}
-        params['compute_attribute']['vm_attrs'][interfaces_attr_name][option_interface_id] = option_interface
+        params['compute_attribute']['vm_attrs'][interfaces_attr_name][option_interface_id] = HammerCLIForeman::ComputeAttribute.alter_interface(option_interface)
         params
       end
       success_message _('Interface was updated.')

--- a/lib/hammer_cli_foreman/compute_resource/base.rb
+++ b/lib/hammer_cli_foreman/compute_resource/base.rb
@@ -3,7 +3,7 @@ module HammerCLIForeman
     class Base
       def name; ''; end
       def compute_attributes; []; end
-      def interface_attributes; []; end
+      def interface_attributes; []; end # all attributes must start with compute_
       def volume_attributes; []; end
       def interfaces_attrs_name; 'interfaces_attributes'; end
       def host_attributes; []; end

--- a/lib/hammer_cli_foreman/compute_resource/libvirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/libvirt.rb
@@ -20,9 +20,9 @@ module HammerCLIForeman
 
       def interface_attributes
         [
-          ['type',   _('Possible values: %s') % 'bridge, network'],
-          ['bridge', _('Name of interface according to type')],
-          ['model',  _('Possible values: %s') % 'virtio, rtl8139, ne2k_pci, pcnet, e1000']
+          ['compute_type',   _('Possible values: %s') % 'bridge, network'],
+          ['compute_bridge', _('Name of interface according to type')],
+          ['compute_model',  _('Possible values: %s') % 'virtio, rtl8139, ne2k_pci, pcnet, e1000']
         ]
       end
 

--- a/lib/hammer_cli_foreman/compute_resource/ovirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/ovirt.rb
@@ -22,9 +22,9 @@ module HammerCLIForeman
 
       def interface_attributes
         [
-          ['name',      _('Compute name, e.g. eth0')],
-          ['network',   _('Select one of available networks for a cluster, must be an ID')],
-          ['interface', _('Interface type')]
+          ['compute_name',      _('Compute name, e.g. eth0')],
+          ['compute_network',   _('Select one of available networks for a cluster, must be an ID')],
+          ['compute_interface', _('Interface type')]
         ]
       end
 


### PR DESCRIPTION
Creating a host with interfaces didn't work properly. 
the reason for that is that in the compute profile PR, I removed the "compute_" string from each attribute in the interfaces, that worked for the compute profile but didn't work for the host creation. 
the reason for that is this functiom: 
```
 def interfaces_attributes
        return [] if option_interface_list.empty?

        # move each attribute starting with "compute_" to compute_attributes
        option_interface_list.collect do |nic|
          compute_attributes = {}
          nic.keys.each do |key|
            if key.start_with? 'compute_'
              compute_attributes[key.gsub('compute_', '')] = nic.delete(key)
            end
          end
          subnet_name = nic.delete('subnet')
          nic['subnet_id'] ||= subnet_id(subnet_name) if subnet_name
          domain_name = nic.delete('domain')
          nic['domain_id'] ||= domain_id(domain_name) if domain_name
          nic['compute_attributes'] = compute_attributes unless compute_attributes.empty?
          nic
        end
      end
```
that puts the interfaces attributes (that are spesfic to a compute resource) inside "compute_attributes"
the function  checks if the attribute starts with "compute" and then puts it under "compute_attributes" 

so I needed to restore the "compute_" string and add a function in compute_attribute that removes it.