### PR TITLE
Refs #27595 - Better prompts for missing arguments

### DIFF
--- a/test/functional/host_test.rb
+++ b/test/functional/host_test.rb
@@ -24,7 +24,7 @@ describe 'host enc-dump' do
     expected_result = CommandExpectation.new
     expected_result.expected_err =
       ['Could not retrieve ENC values of the host:',
-       "  Missing arguments for 'id'",
+       "  Missing arguments for '--id'",
        ''].join("\n")
     expected_result.expected_exit_code = HammerCLI::EX_USAGE
 
@@ -378,7 +378,7 @@ describe 'disassociate host from vm' do
     expected_result = CommandExpectation.new
     expected_result.expected_err = [
       "Failed to disassociated host from VM:",
-      "  Missing arguments for 'id'",
+      "  Missing arguments for '--id'",
       ''].join("\n")
     expected_result.expected_exit_code = HammerCLI::EX_USAGE
 

--- a/test/functional/role_test.rb
+++ b/test/functional/role_test.rb
@@ -12,7 +12,7 @@ describe 'role' do
       expected_result = CommandExpectation.new
       expected_result.expected_err =
         ['Could not clone the user role:',
-         "  Missing arguments for 'id'",
+         "  Missing arguments for '--id'",
          ''].join("\n")
       expected_result.expected_exit_code = HammerCLI::EX_USAGE
 

--- a/test/functional/template_test.rb
+++ b/test/functional/template_test.rb
@@ -12,7 +12,7 @@ describe 'template' do
       expected_result = CommandExpectation.new
       expected_result.expected_err =
         ['Could not clone the provisioning template:',
-         "  Missing arguments for 'id'",
+         "  Missing arguments for '--id'",
          ''].join("\n")
       expected_result.expected_exit_code = HammerCLI::EX_USAGE
 


### PR DESCRIPTION
Fixes tests. After the https://github.com/theforeman/hammer-cli/pull/313 the right way to show missing arguments for `id` is
```
Missing arguments for '--id'
```