### PR TITLE
Fixes #21590 - Use print_output_type to show output adapter

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -262,6 +262,7 @@ module HammerCLIForeman
     end
 
     def execute
+      output.print_output_type
       if should_retrieve_all?
         print_data(retrieve_all)
       else

--- a/lib/hammer_cli_foreman/subnet.rb
+++ b/lib/hammer_cli_foreman/subnet.rb
@@ -37,6 +37,7 @@ module HammerCLIForeman
         field :mask, _("Network Mask")
         field :vlanid, _("VLAN ID")
         field :boot_mode, _("Boot Mode")
+        field :gateway, _("Gateway Address")
       end
 
       build_options


### PR DESCRIPTION
depends on https://github.com/theforeman/hammer-cli/pull/315.