### PR TITLE
Fixes #21590 - Use print_output_type to show output adapter

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -262,6 +262,7 @@ module HammerCLIForeman
     end
 
     def execute
+      output.print_output_type
       if should_retrieve_all?
         print_data(retrieve_all)
       else


### PR DESCRIPTION
The PR depends on: https://github.com/theforeman/hammer-cli/pull/315