### PR TITLE
Fixes #27868 - Add option to support host's param type

### DIFF
--- a/lib/hammer_cli_foreman/hosts/common_update_options.rb
+++ b/lib/hammer_cli_foreman/hosts/common_update_options.rb
@@ -30,6 +30,12 @@ module HammerCLIForeman
 
         base.option "--parameters", "PARAMS", _("Replaces with new host parameters"),
           :format => HammerCLI::Options::Normalizers::KeyValueList.new
+
+        host_params = base.resource.action(base.action).params
+                          .find { |p| p.name == 'host' }.params
+                          .find { |p| p.name == 'host_parameters_attributes' }
+        base.option "--typed-parameters", "TYPED_PARAMS", _("Replaces with new host parameters (with type support)"),
+          :format => HammerCLI::Options::Normalizers::ListNested.new(host_params.params)
         base.option "--compute-attributes", "COMPUTE_ATTRS", _("Compute resource attributes"),
           :format => HammerCLI::Options::Normalizers::KeyValueList.new
         base.option "--volume", "VOLUME", _("Volume parameters"), :multivalued => true,
@@ -72,6 +78,7 @@ module HammerCLIForeman
         params['host']['overwrite'] = option_overwrite unless option_overwrite.nil?
 
         params['host']['host_parameters_attributes'] = parameter_attributes unless option_parameters.nil?
+        params['host']['host_parameters_attributes'] ||= typed_parameter_attributes unless option_typed_parameters.nil?
         params['host']['compute_attributes'] = option_compute_attributes || {}
 
         if action == :update


### PR DESCRIPTION
Requires https://github.com/theforeman/hammer-cli/pull/316

Or we could remove `:host_parameters_attributes` from https://github.com/theforeman/hammer-cli-foreman/blob/9999e05ae70fe68ccfe8fab76c70349dfefe1e45/lib/hammer_cli_foreman/hosts/common_update_options.rb#L45 to build the option from apidocs and thus the core changes will be not required.

Note: if both `--parameters` and `--typed-parameters` are specified then the values from `--parameters` are not overrided by values from `--typed-parameters`.