### PR TITLE
Fixes #28176 - Add http-proxy to hammer

### DIFF
--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -84,6 +84,10 @@ module HammerCLIForeman
       'HammerCLIForeman::Hostgroup', 'hammer_cli_foreman/hostgroup'
     )
 
+    HammerCLI::MainCommand.lazy_subcommand('http-proxy', _("Manipulate http proxies"),
+      'HammerCLIForeman::HttpProxy', 'hammer_cli_foreman/http_proxy'
+    )
+
     HammerCLI::MainCommand.lazy_subcommand('location', _("Manipulate locations"),
       'HammerCLIForeman::Location', 'hammer_cli_foreman/location'
     )

--- a/lib/hammer_cli_foreman/http_proxy.rb
+++ b/lib/hammer_cli_foreman/http_proxy.rb
@@ -1,0 +1,49 @@
+module HammerCLIForeman
+
+    class HttpProxy < HammerCLIForeman::Command
+
+      resource :http_proxies
+
+      class ListCommand < HammerCLIForeman::ListCommand
+
+        output do
+          field :id, _("Id")
+          field :name, _("Name")
+        end
+
+        build_options
+      end
+
+      class InfoCommand < HammerCLIForeman::InfoCommand
+        output ListCommand.output_definition do
+          field :username, _("Username")
+          field :url, _("URL")
+        end
+
+        build_options
+      end
+
+      class CreateCommand < HammerCLIForeman::CreateCommand
+        success_message _("Http proxy created.")
+        failure_message _("Could not create the http proxy")
+
+        build_options
+      end
+
+      class DeleteCommand < HammerCLIForeman::DeleteCommand
+        success_message _("Http proxy deleted.")
+        failure_message _("Could not delete the http proxy")
+
+        build_options
+      end
+
+      class UpdateCommand < HammerCLIForeman::UpdateCommand
+        success_message _("Http proxy updated.")
+        failure_message _("Could not update the http proxy")
+
+        build_options
+      end
+
+      autoload_subcommands
+    end
+end

--- a/test/functional/http_proxy_test.rb
+++ b/test/functional/http_proxy_test.rb
@@ -1,0 +1,69 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe 'httpproxy' do
+  let(:http_proxy) do
+    {
+      :id => 1,
+      :name => 'proxy1',
+      :url => 'http://proxy.example.com',
+      :username => 'user'
+    }
+  end
+
+  it 'list a http proxy' do
+    api_expects(:http_proxies, :index, 'List').with_params(
+      'page' => 1, 'per_page' => 1000
+    ).returns(index_response([http_proxy]))
+
+    output = IndexMatcher.new([
+      ['ID', 'NAME'],
+      ['1',  'proxy1']
+    ])
+    expected_result = success_result(output)
+
+    result = run_cmd(%w(http-proxy list))
+    assert_cmd(expected_result, result)
+  end
+
+  it 'updates an http proxy' do
+    params = ['--id', http_proxy[:id],
+              '--password', 'katello']
+    api_expects(:http_proxies, :update, params)
+      .returns(http_proxy)
+
+    expected_result = success_result("Http proxy updated.\n")
+
+    result = run_cmd(%w(http-proxy update --id 1 --password katello))
+    assert_cmd(expected_result, result)
+  end
+
+  it 'shows info on an http proxy' do
+    params = ['--id', http_proxy[:id]]
+    api_expects(:http_proxies, :show, params)
+      .returns(http_proxy)
+    expected_result = success_result("Id:       1\nName:     proxy1\nUsername: user\nURL:      http://proxy.example.com\n\n")
+    result = run_cmd(%w(http-proxy info --id 1))
+    assert_cmd(expected_result, result)
+  end
+
+  it 'creates an http proxy' do
+    params = ['--url', http_proxy[:key],
+              '--name', http_proxy[:name],
+              '--password', 'foreman',
+              '--username', http_proxy[:username]]
+    api_expects(:http_proxies, :create, params)
+      .returns(http_proxy)
+
+    expected_result = success_result("Http proxy created.\n")
+
+    result = run_cmd(%w(http-proxy create --url "http://proxy.example.com" --name proxy1 --username user --password foreman))
+    assert_cmd(expected_result, result)
+  end
+
+  it 'deletes an http proxy' do
+    expected_result = success_result("Http proxy deleted.\n")
+
+    result = run_cmd(%w(http-proxy delete --id 1))
+    assert_cmd(expected_result, result)
+  end
+end


### PR DESCRIPTION
This PR adds the basic CRUD operations for http-proxies to Hammer