### PR TITLE
Fixes #28135 - GCE CR info shows zone field

### DIFF
--- a/lib/hammer_cli_foreman/compute_resource/gce.rb
+++ b/lib/hammer_cli_foreman/compute_resource/gce.rb
@@ -24,6 +24,7 @@ module HammerCLIForeman
           Fields::Field.new(:label => _('Project'), :path => [:project]),
           Fields::Field.new(:label => _('Email'), :path => [:email]),
           Fields::Field.new(:label => _('Key Path'), :path => [:key_path]),
+          Fields::Field.new(:label => _('Zone'), :path => [:zone])
         ]
       end
 


### PR DESCRIPTION
The response already contains 'zone' attribute, we just don't show it. If the url and the zone are the same it may cause the confusion mentioned in the issue.