### PR TITLE
Fixes #28397 - Re-add owner-id output in hammer host info

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -122,6 +122,7 @@ module HammerCLIForeman
         # additional info
         label _("Additional info") do
           field nil, _("Owner"), Fields::SingleReference, :key => :owner
+          field :owner_id, _("Owner Id")
           field :owner_type, _("Owner Type")
           field :enabled, _("Enabled"), Fields::Boolean
           field nil, _("Model"), Fields::SingleReference, :key => :model, :hide_blank => true


### PR DESCRIPTION
Requested by customer via https://projects.theforeman.org/issues/28397