### PR TITLE
Fixes #28451 - Update taxonomies for auth sources

### DIFF
--- a/lib/hammer_cli_foreman/auth_source.rb
+++ b/lib/hammer_cli_foreman/auth_source.rb
@@ -18,7 +18,16 @@ module HammerCLIForeman
       build_options
     end
 
+    class UpdateCommand < HammerCLIForeman::UpdateCommand
+      desc _('Update organization and location for Auth Source')
+      resource :auth_source_externals
+  
+      success_message _('Taxonomy updated.')
+      failure_message _('Taxonomy not changed. Please check if appropriate auth source exists')
+
+      build_options
+    end
+
     autoload_subcommands
   end
-
 end


### PR DESCRIPTION
With this patch, one can assign taxonomy to an auth-sources. The aim of this PR is to assign External Auth Source a toxonomy. For example,

```
$ hammer -d auth-source update --id 3 --location-id 2 --organization-id 1
```

