### PR TITLE
Refs #28135 - Remove URL field from GCE info

### DIFF
--- a/lib/hammer_cli_foreman/compute_resource.rb
+++ b/lib/hammer_cli_foreman/compute_resource.rb
@@ -31,7 +31,6 @@ module HammerCLIForeman
       include ProviderNameLegacy
 
       output ListCommand.output_definition do
-        field :url, _("Url")
         field :description, _("Description")
         field :user, _("User")
         HammerCLIForeman::References.taxonomies(self)

--- a/lib/hammer_cli_foreman/compute_resource/base.rb
+++ b/lib/hammer_cli_foreman/compute_resource/base.rb
@@ -7,7 +7,11 @@ module HammerCLIForeman
       def volume_attributes; []; end
       def interfaces_attrs_name; 'interfaces_attributes'; end
       def host_attributes; []; end
-      def provider_specific_fields; []; end
+      def provider_specific_fields
+        [
+          Fields::Field.new(label: _('Url'), path: [:url]) 
+        ]
+      end
       def mandatory_resource_options; %i[name provider]; end
     end
   end

--- a/lib/hammer_cli_foreman/compute_resource/ec2.rb
+++ b/lib/hammer_cli_foreman/compute_resource/ec2.rb
@@ -10,7 +10,7 @@ module HammerCLIForeman
       end
 
       def provider_specific_fields
-        [
+        super + [
           Fields::Field.new(:label => _('Region'), :path => [:region])
         ]
       end

--- a/lib/hammer_cli_foreman/compute_resource/openstack.rb
+++ b/lib/hammer_cli_foreman/compute_resource/openstack.rb
@@ -10,7 +10,7 @@ module HammerCLIForeman
       end
 
       def provider_specific_fields
-        [
+        super + [
           Fields::Field.new(:label => _('Tenant'), :path => [:tenant]),
           Fields::Field.new(:label => _('Project domain name'), :path => [:project_domain_name]),
           Fields::Field.new(:label => _('Project domain ID'), :path => [:project_domain_id])

--- a/lib/hammer_cli_foreman/compute_resource/ovirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/ovirt.rb
@@ -41,7 +41,7 @@ module HammerCLIForeman
       end
 
       def provider_specific_fields
-        [
+        super + [
           Fields::Field.new(:label => _('Datacenter'), :path => [:datacenter])
         ]
       end

--- a/lib/hammer_cli_foreman/compute_resource/rackspace.rb
+++ b/lib/hammer_cli_foreman/compute_resource/rackspace.rb
@@ -10,7 +10,7 @@ module HammerCLIForeman
       end
 
       def provider_specific_fields
-        [
+        super + [
           Fields::Field.new(:label => _('Region'), :path => [:region])
         ]
       end

--- a/lib/hammer_cli_foreman/compute_resource/vmware.rb
+++ b/lib/hammer_cli_foreman/compute_resource/vmware.rb
@@ -61,7 +61,7 @@ module HammerCLIForeman
       end
 
       def provider_specific_fields
-        [
+        super + [
           Fields::Field.new(:label => _('Datacenter'), :path => [:datacenter]),
           Fields::Field.new(:label => _('Server'), :path => [:server])
         ]


### PR DESCRIPTION
This should be also cherry-picked into 0.19-stable for 0.19.5.