### PR TITLE
Fixes #28503 - Increase ID column width for available networks

### DIFF
--- a/lib/hammer_cli_foreman/compute_resource.rb
+++ b/lib/hammer_cli_foreman/compute_resource.rb
@@ -121,7 +121,7 @@ module HammerCLIForeman
       command_name 'networks'
 
       output do
-        field :id, _('Id')
+        field :id, _('Id'), Fields::Field, :max_width => 200, :hide_blank => true
         field :name, _('Name')
       end
 


### PR DESCRIPTION
The available_networks call for the azure compute resource lists the id and name, but the id is too long and hence, gets trimmed that blocks the user to go ahead and provide interfaces_attributes while creating a host. The PR handles that width of the ID column.