### PR TITLE
Fixes #28541 - Fix host creation from image and hostgroup

### DIFF
--- a/lib/hammer_cli_foreman/compute_resource/utils.rb
+++ b/lib/hammer_cli_foreman/compute_resource/utils.rb
@@ -8,6 +8,22 @@ module HammerCLIForeman
       )
     end
 
+    def self.get_hostgroup_compute_resource_id(hostgroup_id)
+      hostgroup = HammerCLIForeman.record_to_common_format(
+          HammerCLIForeman.foreman_resource(:hostgroups).call(:show, 'id' => hostgroup_id)
+      )
+      compute_resource_id = hostgroup['compute_resource_id']
+       if !hostgroup['compute_resource_name'].to_s.strip.empty? && compute_resource_id.nil?
+         compute_resource= HammerCLIForeman.record_to_common_format(
+            HammerCLIForeman.foreman_resource(:compute_resources).call(
+                :index, :search => "name = \"#{hostgroup['compute_resource_name']}\""
+            )
+         )
+         compute_resource_id = compute_resource['results'][0]['id'] if compute_resource['results'][0]
+      end
+      compute_resource_id
+    end
+
     def self.get_host_compute_resource_id(host_id)
       HammerCLIForeman.record_to_common_format(
         HammerCLIForeman.foreman_resource(:hosts).call(

--- a/lib/hammer_cli_foreman/hosts/common_update_options.rb
+++ b/lib/hammer_cli_foreman/hosts/common_update_options.rb
@@ -98,9 +98,14 @@ module HammerCLIForeman
           params['host']['compute_attributes']['volumes_attributes'] = nested_attributes(option_volume_list)
           params['host']['interfaces_attributes'] = interfaces_attributes
         end
-
-        if options["option_image_id"]
-          compute_resource_id = params['host']['compute_resource_id'] || ::HammerCLIForeman::ComputeResources.get_host_compute_resource_id(params['id'])
+        if options['option_image_id']
+          if params['host']['compute_resource_id']
+            compute_resource_id = params['host']['compute_resource_id']
+          elsif params['id']
+            compute_resource_id = ::HammerCLIForeman::ComputeResources.get_host_compute_resource_id(params['id'])
+          elsif params['host']['hostgroup_id']
+            compute_resource_id = ::HammerCLIForeman::ComputeResources.get_hostgroup_compute_resource_id(params['host']['hostgroup_id'])
+          end
           raise ArgumentError, "Missing argument for 'compute_resource'" if compute_resource_id.nil?
           image_uuid =  ::HammerCLIForeman::ComputeResources.get_image_uuid(compute_resource_id, options["option_image_id"])
           params['host']['compute_attributes']['image_id'] = image_uuid


### PR DESCRIPTION
In the code we are translating the forman image id to the provider image_id and put it under ['host']['compute_attributes']['image_id'], 
the problem is that we relied on compute_resource_id to exist or host_id (in case of update) and we didn't address a commend that send only with hostgroup, 
this PR should fix the issue. 