### PR TITLE
Unpin mocha version & fix deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'minitest', '4.7.4'
   gem 'minitest-spec-context'
   gem 'simplecov'
-  gem 'mocha', '<=1.9.0'
+  gem 'mocha'
   gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ SimpleCov.root Pathname.new(File.dirname(__FILE__) + "../../../")
 require 'minitest/autorun'
 require 'minitest/spec'
 require "minitest-spec-context"
-require "mocha/setup"
+require "mocha/minitest"
 
 require 'hammer_cli'
 require 'hammer_cli_foreman/testing/api_expectations'


### PR DESCRIPTION
The regression introduced in mocha v1.10.0 which led to its version being pinned to v1.9.0 was fixed in mocha v1.11.2 which is currently the latest version, so it is now safe to unpin the version.

Requiring 'mocha/setup' was deprecated in v1.10.0, so I've also fixed that with the change to `test/test_helper.rb`.

Fixes [Redmine issue 28420][1].

[1]: https://projects.theforeman.org/issues/28420