### PR TITLE
Fixes #28646 - fix unauthorized user error message

### DIFF
--- a/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
+++ b/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
@@ -55,7 +55,7 @@ module HammerCLIForeman
       def error(ex)
         if ex.is_a?(RestClient::Unauthorized) && session.valid?
           if @user_changed
-            return UnauthorizedError.new(_("Invalid username or password, continuing with session for '%s'.") % session.user_name)
+            return UnauthorizedError.new(_("Invalid credentials, continuing with session for '%s'.") % session.user_name)
           else
             session.destroy
             return SessionExpired.new(_("Session has expired."))

--- a/test/unit/api/session_authenticator_wrapper_test.rb
+++ b/test/unit/api/session_authenticator_wrapper_test.rb
@@ -211,7 +211,7 @@ describe HammerCLIForeman::Api::SessionAuthenticatorWrapper do
             ex = RestClient::Unauthorized.new
             new_ex = auth.error(ex)
 
-            assert_equal "Invalid username or password, continuing with session for 'admin'.", new_ex.message
+            assert_equal "Invalid credentials, continuing with session for 'admin'.", new_ex.message
           end
         end
 


### PR DESCRIPTION
Trying to login with incorrect credentials when a user is already logged in, the error message shows something like: invalid username and password. Since we have multiple auth source types present now, we can change the message to something like: invalid credentials.