### PR TITLE
Fixes #29096 - Remove duplicate API requests on AddAssociatedCommand

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -671,8 +671,12 @@ module HammerCLIForeman
 
     def get_new_ids
       ids = get_current_ids.map(&:to_s)
-      required_ids = get_associated_identifiers.nil? ? [] : get_associated_identifiers.map(&:to_s)
-      required_ids << get_associated_identifier.to_s unless get_associated_identifier.nil?
+
+      associated_identifiers = get_associated_identifiers
+      associated_identifier = get_associated_identifier
+
+      required_ids = associated_identifiers.nil? ? [] : associated_identifiers.map(&:to_s)
+      required_ids << associated_identifier.to_s unless associated_identifier.nil?
 
       ids += required_ids
       ids.uniq


### PR DESCRIPTION
#494 introduced a change which caused hammer-cli-katello tests to fail because of duplicate API requests. This PR cleans that up.

This should be cherry-picked onto the 2.0 branch as well

tail the app logs and watch the requests when running an 'add associated command' such as

```
hammer content-view add-version --id 1 --content-view-id 3 --content-view-version 2.1
```

the index method for the associated object is called twice