### PR TITLE
Fixes #29274 - Use right param for os default template

### DIFF
--- a/lib/hammer_cli_foreman/operating_system.rb
+++ b/lib/hammer_cli_foreman/operating_system.rb
@@ -136,7 +136,7 @@ module HammerCLIForeman
         params = {
           "os_default_template" => {
             "provisioning_template_id" => option_provisioning_template_id,
-            "provisioning_kind_name" => tpl_kind_name
+            "template_kind_name" => tpl_kind_name
           }
         }.merge base_action_params
 


### PR DESCRIPTION
I guess this should be CPed into 2.0-stable.