### PR TITLE
Add rake task with plugin template

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'ci/reporter/rake/minitest'
 require 'hammer_cli/i18n/find_task'
 require_relative './lib/hammer_cli_foreman/version'
 require_relative './lib/hammer_cli_foreman/i18n'
+require_relative './lib/hammer_cli_foreman/task_helper'
 
 Rake::TestTask.new do |t|
   t.libs.push "lib"
@@ -16,4 +17,44 @@ HammerCLI::I18n::FindTask.define(HammerCLIForeman::I18n::LocaleDomain.new, Hamme
 namespace :pkg do
   desc 'Generate package source gem'
   task :generate_source => :build
+end
+
+namespace :plugin do
+  desc 'Create a plugin draft interactively'
+  task :draft do |_t, args|
+    require 'highline/import'
+    require 'uri'
+
+    options = {}
+    options[:path] = ask('Directory to create the draft in: ') { |dir| dir.default = '../' }
+    options[:name] = ask('Plugin name (e.g. my_plugin): ', String) do |name|
+      name.validate = /\A[a-zA-Z]+([-_][a-zA-Z]+)*\Z/
+      name.responses[:not_valid] = 'Valid names are: my_plugin, my-plugin, MyPlugin'
+    end
+    options[:author] = ask("Plugin's author (e.g. John Doe): ", String) do |author|
+      author.validate = /\A[a-zA-Z]++(?: [a-zA-Z]++)*\Z/
+      author.responses[:not_valid] = 'Valid names are: John, John Doe, John Doe S'
+    end
+    options[:email] = ask("Plugin's author e-mail (e.g. johndoe@example.com): ", String) do |email|
+      email.validate = URI::MailTo::EMAIL_REGEXP
+      email.responses[:not_valid] = 'Valid email is: johndoe@example.com'
+    end
+    options[:name] = options[:name].downcase.tr('-', '_')
+
+    draft = HammerCLIForeman::TaskHelper::PluginDraft.new(
+      options[:name], options[:path], author: options[:author], email: options[:email]
+    )
+    draft.build
+    draft.fill do
+      mk_config
+      cp_license
+      mk_readme
+      mk_gemfile
+      mk_gemspec
+      mk_version
+      mk_root
+      mk_boilerplate
+    end
+    puts "Saved in #{draft.path}."
+  end
 end

--- a/doc/developer_docs.md
+++ b/doc/developer_docs.md
@@ -10,6 +10,7 @@ Foreman plugin extends the Hammer Core in following areas:
  - [Building options](option_builder.md#option-builders)
  - [Automatic name resolution](name_id_resolution.md#name-to-id-resolution)
  - [Testing commands](testing.md#testing-hammer-commands)
+ - [Writing a plugin](plugin.md#writing-a-plugin)
 
 It's recommended that you set `:refresh_cache: true` in the plugin settings if
 engaging in API development to enable aggressive apidoc cache checking.

--- a/doc/plugin.md
+++ b/doc/plugin.md
@@ -1,0 +1,22 @@
+# Writing a plugin
+
+### Basic
+
+If you want to create a plugin for hammer-cli-foreman, you might want to create
+a simple draft at first.
+
+To do so, just run the following:
+```
+# You will need to checkout this repository first if you don't have it already
+$ git checkout https://github.com/theforeman/hammer-cli-foreman.git
+$ cd hammer-cli-foreman
+$ rake plugin:draft
+# fill prompts
+```
+This will create a directory called `hammer-cli-foreman-prompted-name` with
+basic structure where you can put your code afterwards. Please, don't forget to
+take a look at `TODO`s as there might be places you want to change or adjust to
+your needs first.
+
+For more information, please see: https://github.com/theforeman/hammer-cli/blob/master/doc/developer_docs.md
+as well as https://github.com/theforeman/hammer-cli-foreman/blob/master/doc/developer_docs.md

--- a/lib/hammer_cli_foreman.rb
+++ b/lib/hammer_cli_foreman.rb
@@ -11,6 +11,7 @@ module HammerCLIForeman
   require 'hammer_cli_foreman/i18n'
 
   require 'hammer_cli_foreman/version'
+  require 'hammer_cli_foreman/task_helper'
   require 'hammer_cli_foreman/output'
   require 'hammer_cli_foreman/output/fields'
   require 'hammer_cli_foreman/exception_handler'

--- a/lib/hammer_cli_foreman/task_helper.rb
+++ b/lib/hammer_cli_foreman/task_helper.rb
@@ -1,0 +1,180 @@
+require 'fileutils'
+
+module HammerCLIForeman
+  module TaskHelper
+    class PluginDraft
+      attr_reader :name, :path
+
+      def initialize(name, path, options = {})
+        @plain_name = name
+        @name = "hammer_cli_foreman_#{name}"
+        @path = File.expand_path(@name.tr('_', '-'), path)
+        @capitalized_bits = name.split('_').map(&:capitalize)
+        @plugin_namespace = "HammerCLIForeman#{@capitalized_bits.join}"
+        @core_location = File.expand_path('../../', File.dirname(__FILE__))
+        @options = options
+      end
+
+      def build
+        FileUtils.mkpath("#{@path}/lib/#{@name}")
+        FileUtils.mkpath("#{@path}/config")
+        FileUtils.mkpath("#{@path}/test")
+        FileUtils.mkpath("#{@path}/locale")
+      end
+
+      def fill(&block)
+        FileUtils.cd(@path) do
+          self.instance_exec(&block)
+        end
+      end
+
+      private
+
+      def cp_license
+        FileUtils.cp(File.expand_path('LICENSE', @core_location), FileUtils.pwd)
+      end
+
+      def mk_config
+        File.open("config/foreman_#{@plain_name}.yml", 'w') do |config|
+          config.write <<-EOF
+:foreman_#{@plain_name}:
+  :enable_module: true
+EOF
+        end
+      end
+
+      def mk_readme
+        File.open('README.md', 'w') do |readme|
+          readme.write <<-EOF
+# TODO
+EOF
+        end
+      end
+
+      def mk_gemfile
+        File.open('Gemfile', 'w') do |gemfile|
+          gemfile.write <<-EOF
+source "https://rubygems.org"
+
+gemspec
+EOF
+        end
+      end
+
+      def mk_gemspec
+        File.open("#{@name}.gemspec", 'w') do |gemspec|
+          gemspec.write <<-EOF
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require '#{@name}/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = '#{@name}'
+  spec.version       = #{@plugin_namespace}.version.dup
+  spec.authors       = ['#{@options[:author]}']
+  spec.email         = ['#{@options[:email]}']
+  spec.homepage      = 'https://github.com/theforeman/#{@name.tr('_', '-')}'
+  spec.license       = 'GPL-3.0'
+
+  spec.platform      = Gem::Platform::RUBY
+  spec.summary       = 'Foreman #{@capitalized_bits.join(' ')} plugin for Hammer CLI'
+
+  # TODO: Don't forget to update required files accordingly!
+  spec.files         = Dir['{lib,config}/**/*', 'LICENSE', 'README*']
+  spec.require_paths = ['lib']
+  spec.test_files    = Dir['{test}/**/*']
+
+  spec.add_dependency 'hammer_cli_foreman', '>= 2.0.0', '< 3.0.0'
+end
+EOF
+        end
+      end
+
+      def mk_version
+        File.open("lib/#{@name}/version.rb", 'w') do |version|
+          version.write <<-EOF
+module #{@plugin_namespace}
+  def self.version
+    @version ||= Gem::Version.new '0.0.1'
+  end
+end
+EOF
+        end
+      end
+
+      def mk_root
+        File.open("lib/#{@name}.rb", 'w') do |plugin|
+          plugin.write <<-EOF
+module #{@plugin_namespace}
+  require 'hammer_cli'
+  require 'hammer_cli_foreman'
+
+  require '#{@name}/version'
+  require '#{@name}/resource'
+
+  HammerCLI::MainCommand.lazy_subcommand(
+    'resource',
+    'Manage resources',
+    '#{@plugin_namespace}::ResourceCommand',
+    '#{@name}/resource'
+  )
+end
+EOF
+        end
+      end
+
+      def mk_boilerplate
+        File.open("lib/#{@name}/resource.rb", 'w') do |resource_command|
+          resource_command.write <<-EOF
+module #{@plugin_namespace}
+  class ResourceCommand < HammerCLIForeman::Command
+    resource :resources
+
+    class ListCommand < HammerCLIForeman::ListCommand
+      output do
+        field :id, _('Id')
+        field :name, _('Name')
+      end
+
+      build_options
+    end
+
+    class InfoCommand < HammerCLIForeman::InfoCommand
+      output ResourceCommand::ListCommand.output_definition do
+        field :head_type, _('Head type')
+      end
+
+      build_options
+    end
+
+    class CreateCommand < HammerCLIForeman::CreateCommand
+      success_message _('Resource created.')
+      failure_message _('Could not create the resource')
+
+      build_options
+    end
+
+    class UpdateCommand < HammerCLIForeman::UpdateCommand
+      success_message _('Resource updated.')
+      failure_message _('Could not update the resource')
+
+      build_options without: [:sprig]
+      option '--head', 'HEAD', _('Head type'), attribute_name: :option_head
+    end
+
+    class DeleteCommand < HammerCLIForeman::DeleteCommand
+      success_message _('Resource deleted.')
+      failure_message _('Could not delete the resource')
+
+      build_options
+    end
+
+    autoload_subcommands
+  end
+end
+EOF
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a possibility to generate a simple draft for a new plugin via rake task `rake plugin:draft -- [options]`.

I'm not sure though whether this should be a rake task, hammer subcommand or hammer executable, or just directory with files...