### PR TITLE
[WIP] Fixes #29575 - Session after expiration considers the present auth type

### DIFF
--- a/lib/hammer_cli_foreman/api/connection.rb
+++ b/lib/hammer_cli_foreman/api/connection.rb
@@ -52,9 +52,8 @@ module HammerCLIForeman
         return AUTH_TYPES[:basic_auth] unless HammerCLIForeman::Sessions.enabled?
 
         url = settings.get(:_params, :host) || settings.get(:foreman, :host)
-        username = settings.get(:_params, :username) || settings.get(:foreman, :username)
         session = HammerCLIForeman::Sessions.get(url)
-        if !session.valid? && session.user_name == username && !session.auth_type.nil?
+        if !session.valid? && !session.auth_type.nil?
           session.auth_type
         else
           # If the caller has not sepcified an 'auth_type'


### PR DESCRIPTION
With the changes merged related to SSO, the session is created properly, contains the auth type but when I run some hammer command it tries to login with basic auth and asks for username as it was ignoring the session at all.

With the patch, there is still a issue. For the first time when user session expires, hammer asks for username and password. While from the second time it checks for the Auth type in the session and gives correct output.