### PR TITLE
Revert "Refs #28601 - skip one test on Ruby 2.7"

### DIFF
--- a/test/functional/http_proxy_test.rb
+++ b/test/functional/http_proxy_test.rb
@@ -64,9 +64,6 @@ describe 'httpproxy' do
     expected_result = success_result("Http proxy deleted.\n")
 
     result = run_cmd(%w(http-proxy delete --id 1))
-    # Skip this assertion until a version of awesome_print without warnings on Ruby 2.7 is available
-    if RUBY_VERSION < '2.7'
-      assert_cmd(expected_result, result)
-    end
+    assert_cmd(expected_result, result)
   end
 end


### PR DESCRIPTION
This reverts commit 482ce1bbb836c200d9f6e13cddc97028d5e8ebed.