### PR TITLE
Fixes #14660 - fixed bug in fact list display

### DIFF
--- a/lib/hammer_cli_foreman/fact.rb
+++ b/lib/hammer_cli_foreman/fact.rb
@@ -20,6 +20,7 @@ module HammerCLIForeman
 
       def self.unhash_facts(facts_collection)
         facts = facts_collection.first.inject([]) do |list, (host, facts)|
+          facts.compact!
           list + facts.collect do |(fact, value)|
             { :host => host, :fact => fact, :value => value }
           end


### PR DESCRIPTION
hammer fact list displays categories in addition to actual facts.
This PR fixes this problem and now the display is correct.