### PR TITLE
Fixes #30886 - added missing tests to setting

### DIFF
--- a/lib/hammer_cli_foreman/settings.rb
+++ b/lib/hammer_cli_foreman/settings.rb
@@ -32,6 +32,20 @@ module HammerCLIForeman
       build_options
     end
 
+    class InfoCommand < HammerCLIForeman::InfoCommand
+      output do
+        field :id, _("Id")
+        field :name, _("Name")
+        field :description, _("Description")
+        field :category_name, _("Category")
+        field :settings_type, _("Settings type")
+        field :value, _("Value")
+      end
+
+      build_options
+    end
+
+
     autoload_subcommands
   end
 

--- a/test/functional/settings_test.rb
+++ b/test/functional/settings_test.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'test_helper')
+require File.join(File.dirname(__FILE__), 'test_helper')
 
 describe 'Settings' do
   let(:setting) do
@@ -31,6 +31,62 @@ describe 'Settings' do
       assert_cmd(expected_result, result)
     end
 
+  end
+
+  describe 'info' do
+    before do
+      @cmd = ['setting', 'info']
+      @setting = {
+        description: 'Fix DB cache on next Foreman restart',
+        category: 'Setting::General',
+        settings_type: 'boolean',
+        default: false,
+        created_at: "2020-05-24 09:02:11 UTC",
+        updated_at: "2020-07-01 07:42:14 UTC",
+        id: 1,
+        name: "fix_db_cache",
+        full_name: "Fix DB cache",
+        value: false,
+        category_name: "General"
+      }
+    end
+
+    it 'should return a setting' do
+      params = ['--id=1']
+      api_expects(:settings, :show, 'Show a setting').returns(@setting)
+
+      output = OutputMatcher.new([
+                                   'Id:            1',
+                                   'Name:          fix_db_cache',
+                                   'Description:   Fix DB cache on next Foreman restart',
+                                   'Category:      General',
+                                   'Settings type: boolean',
+                                   'Value:         false'
+                                 ])
+
+      expected_result = success_result(output)
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(expected_result, result)
+    end
+  end
+
+  describe 'update' do
+    before do
+      @cmd = ['setting', 'set']
+    end
+
+    it 'should update a setting' do
+      params = ['--id=1', '--value=true']
+
+      api_expects(:settings, :update, 'Update a setting') do |params|
+        (params['setting']['id'] == '1')
+        (params['setting']['value'] == 'true')
+      end
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(success_result("Setting [%{name}] updated to [%{value}].\n"), result)
+    end
   end
 
 end


### PR DESCRIPTION
The setting command in hammer was missing the show and update tests.