### PR TITLE
Fixes #30910 - Better option assignment for nested params

### DIFF
--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -548,10 +548,12 @@ module HammerCLIForeman
       builder
     end
 
-    def method_options_for_params(params, include_nil=true)
+    def method_options_for_params(params, options)
       opts = super
       # overwrite searchables with correct values
       searchables.for(resource).each do |s|
+        next unless params.map(&:name).include?(s.name)
+
         new_value = get_option_value("new_#{s.name}")
         opts[s.name] = new_value unless new_value.nil?
       end

--- a/test/functional/compute_profile_test.rb
+++ b/test/functional/compute_profile_test.rb
@@ -33,8 +33,10 @@ describe "parameters" do
           }
     end
     it 'update compute profile name' do
-      params = ['--id=1' ,'--new-name=profile2']
-      api_expects(:compute_profiles, :update, 'Update the compute profile').with_params({"name" =>"profile2"}).returns(@compute_profile)
+      params = ['--id=1', '--new-name=profile2']
+      api_expects(:compute_profiles, :update, 'Update the compute profile').with_params(
+        { 'compute_profile' => { 'name' => 'profile2' } }
+      ).returns(@compute_profile)
       result = run_cmd(@cmd + params)
       assert_cmd(success_result("Compute profile updated.\n"), result)
     end

--- a/test/functional/host_test.rb
+++ b/test/functional/host_test.rb
@@ -315,6 +315,26 @@ describe 'host update' do
     }
   end
 
+  it 'updates with passed options only' do
+    params = ['--new-name=new-name']
+    expected_result = success_result("Host updated.\n")
+
+    api_expects(:hosts, :update, 'Update host name only').with_params(
+      'id' => '1', 'organization_id' => 1, 'location_id' => 1,
+      'host' => { 'name' => 'new-name' }
+    ).returns(
+      {
+        'id' => '1',
+        'name' => 'new-name',
+        'organization_id' => '1',
+        'location_id' => '1'
+      }
+    )
+
+    result = run_cmd(cmd + minimal_params + params)
+    assert_cmd(expected_result, result)
+  end
+
   it 'ensures helper methods are invoked' do
     params = ['--image-id=1']
     expected_result = success_result("Host updated.\n")
@@ -350,12 +370,9 @@ describe 'host update' do
     )
     api_expects(:hosts, :update, 'Update host with new org').with_params(
       'id' => '1', 'location_id' => 1, 'organization_id' => 1, 'host' => {
-        'organization_id' => '5', 'compute_attributes' => {}
-      }
+        'organization_id' => '5' }
     ) do |par|
-      par['id'] == '1' &&
-        par['host']['organization_id'] == '5' &&
-        par['host']['compute_attributes'] == {}
+      par['id'] == '1' && par['host']['organization_id'] == '5'
     end.returns(updated_host)
 
     expected_result = success_result("Host updated.\n")
@@ -373,12 +390,9 @@ describe 'host update' do
     )
     api_expects(:hosts, :update, 'Update host with new loc').with_params(
       'id' => '1', 'location_id' => 1, 'organization_id' => 1, 'host' => {
-        'location_id' => '5', 'compute_attributes' => {}
-      }
+        'location_id' => '5' }
     ) do |par|
-      par['id'] == '1' &&
-        par['host']['location_id'] == '5' &&
-        par['host']['compute_attributes'] == {}
+      par['id'] == '1' && par['host']['location_id'] == '5'
     end.returns(updated_host)
 
     expected_result = success_result("Host updated.\n")
@@ -396,12 +410,9 @@ describe 'host update' do
     )
     api_expects(:hosts, :update, 'Update host with new owner').with_params(
         'id' => '1', 'location_id' => 1, 'organization_id' => 1, 'host' => {
-        'owner_id' => '1', 'compute_attributes' => {}
-    }
+        'owner_id' => '1' }
     ) do |par|
-      par['id'] == '1' &&
-          par['host']['owner_id'] == '1' &&
-          par['host']['compute_attributes'] == {}
+      par['id'] == '1' && par['host']['owner_id'] == '1'
     end.returns(updated_host)
 
     expected_result = success_result("Host updated.\n")

--- a/test/functional/realm_test.rb
+++ b/test/functional/realm_test.rb
@@ -93,7 +93,7 @@ describe 'realm' do
 
       api_expects(:realms, :update, 'Update a realm') do |params|
         (params['id'] == '1' &&
-         params['name'] == 'test-realm-update')
+         params['realm']['name'] == 'test-realm-update')
       end
 
       result = run_cmd(@cmd + params)
@@ -101,4 +101,3 @@ describe 'realm' do
     end
   end
 end
-

--- a/test/functional/role_test.rb
+++ b/test/functional/role_test.rb
@@ -40,9 +40,9 @@ describe 'role' do
     it 'should clone a role by id' do
       params = ['--id=1', '--new-name=zzz']
 
-      api_expects(:roles, :clone, 'Clone role').with_params({
-        'id' => '1', 'role' => {'name' => 'zzz'}, 'name' => 'zzz'
-      })
+      api_expects(:roles, :clone, 'Clone role').with_params(
+        { 'id' => '1', 'role' => { 'name' => 'zzz' } }
+      )
 
       result = run_cmd(@cmd + params)
       assert_cmd(success_result("User role cloned.\n"), result)
@@ -51,16 +51,13 @@ describe 'role' do
     it 'should clone a role by name' do
       params = ['--name=old', '--new-name=zzz']
 
-      api_expects_search(:roles, { :name => 'old' }, 'Attempt find role').returns(
-        index_response(
-          [{
-              'name' => 'old',
-              'id' => 1
-          }]))
+      api_expects_search(:roles, { name: 'old' }, 'Attempt find role').returns(
+        index_response([{ 'name' => 'old', 'id' => 1 }])
+      )
 
-      api_expects(:roles, :clone, 'Clone role').with_params({
-        'id' => 1, 'role' => {'name' => 'zzz'}, 'name' => 'zzz'
-      })
+      api_expects(:roles, :clone, 'Clone role').with_params(
+        { 'id' => 1, 'role' => { 'name' => 'zzz' } }
+      )
 
       result = run_cmd(@cmd + params)
       assert_cmd(success_result("User role cloned.\n"), result)

--- a/test/unit/media_test.rb
+++ b/test/unit/media_test.rb
@@ -95,7 +95,7 @@ describe HammerCLIForeman::Medium do
     end
 
     with_params ["--id=1", "--new-name=medium_x", "--path=http://some.path/", "--operatingsystem-ids=1,2"] do
-      it_should_call_action :update, {'id' => '1', 'name' => 'medium_x', 'medium' => {'name' => 'medium_x', 'path' => 'http://some.path/', 'operatingsystem_ids' => ['1','2']}}
+      it_should_call_action :update, {'id' => '1', 'medium' => {'name' => 'medium_x', 'path' => 'http://some.path/', 'operatingsystem_ids' => ['1','2']}}
     end
 
   end

--- a/test/unit/partition_table_test.rb
+++ b/test/unit/partition_table_test.rb
@@ -119,8 +119,8 @@ describe HammerCLIForeman::PartitionTable do
       # TODO: temporarily disabled, parameters are checked in the id resolver
     end
 
-    with_params ["--id=83", "--new-name=ptable","--file=~/table.sh", "--os-family=RedHat"] do
-      it_should_call_action :update, {'id' => '83', 'name' => 'ptable', 'ptable' => {'name' => 'ptable', 'layout' => 'FILE_CONTENT', 'os_family' => 'RedHat'}}
+    with_params ['--id=83', '--new-name=ptable', '--file=~/table.sh', '--os-family=RedHat'] do
+      it_should_call_action :update, { 'id' => '83', 'ptable' => { 'name' => 'ptable', 'layout' => 'FILE_CONTENT', 'os_family' => 'RedHat' } }
     end
 
   end

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -77,8 +77,8 @@ describe HammerCLIForeman::Role do
       it_should_accept "name and new name", ["--name=role", "--new-name=role2"]
     end
 
-    with_params ["--id=1", "--new-name=role2"] do
-      it_should_call_action :update, {'id' => '1', 'name' => 'role2', 'role' => {'name' => 'role2'}}
+    with_params ['--id=1', '--new-name=role2'] do
+      it_should_call_action :update, { 'id' => '1', 'role' => { 'name' => 'role2' } }
     end
 
   end


### PR DESCRIPTION
~~Because `params['host']['compute_attributes']` was being set to an empty hash even if the option was not provided, the redundant param was being sent to the server. That's not quite right.~~

Also, which is more important, I've noticed (thanks to the test in this PR) that there is some mess with those nested hash params:
` $ hammer host update --id 4 --new-name lera `
![ScreenShot-1600950263532](https://user-images.githubusercontent.com/32508194/94144720-cb12fc00-fe71-11ea-95ae-f3940325a82c.png)
![ScreenShot-1600950360150](https://user-images.githubusercontent.com/32508194/94144807-e54cda00-fe71-11ea-810c-f0f3a00f9c64.png)

~~Even though the server ignores redundant stuff, I guess we should fix that as well: https://projects.theforeman.org/issues/30910~~

Requires https://github.com/theforeman/hammer-cli/pull/336.