### PR TITLE
Adding download policy to info fields

### DIFF
--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -30,6 +30,7 @@ module HammerCLIForeman
           custom_field Fields::Reference
         end
         HammerCLIForeman::References.taxonomies(self)
+        field :download_policy, _("Download Policy")
         HammerCLIForeman::References.timestamps(self)
       end
 


### PR DESCRIPTION
hammer proxy info --id <id> now shows the download policy for the given smart proxy.

