### PR TITLE
Fixes #32265 - Support unrecognized services in ping

### DIFF
--- a/lib/hammer_cli_foreman/ping.rb
+++ b/lib/hammer_cli_foreman/ping.rb
@@ -19,7 +19,12 @@ module HammerCLIForeman
         response = send_request
         print_data(response)
 
-        return 1 if HammerCLIForeman::CommandExtensions::Ping.failed?(response)
+        if HammerCLIForeman::CommandExtensions::Ping.failed?(response)
+          HammerCLIForeman::CommandExtensions::Ping.check_for_unrecognized(
+            response, output_definition
+          )
+          return 1
+        end
 
         HammerCLI::EX_OK
       end


### PR DESCRIPTION
@ekohl, probably you want to review/test this as well.

This should add a warning message in case if a service failed and is not listed in the output.

![ScreenShot-1602617557330](https://user-images.githubusercontent.com/32508194/95907355-ae485500-0d9b-11eb-924e-2ddb81ea0aea.png)
 