### PR TITLE
Fixes #31384 - fix hammer list failure when defaults are set

### DIFF
--- a/lib/hammer_cli_foreman/architecture.rb
+++ b/lib/hammer_cli_foreman/architecture.rb
@@ -11,7 +11,7 @@ module HammerCLIForeman
         field :name, _("Name")
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -23,7 +23,7 @@ module HammerCLIForeman
         HammerCLIForeman::References.timestamps(self)
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -31,7 +31,7 @@ module HammerCLIForeman
       success_message _("Architecture created.")
       failure_message _("Could not create the architecture")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -39,7 +39,7 @@ module HammerCLIForeman
       success_message _("Architecture deleted.")
       failure_message _("Could not delete the architecture")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -47,7 +47,7 @@ module HammerCLIForeman
       success_message _("Architecture updated.")
       failure_message _("Could not update the architecture")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     HammerCLIForeman::AssociatingCommands::OperatingSystem.extend_command(self)

--- a/lib/hammer_cli_foreman/bookmark.rb
+++ b/lib/hammer_cli_foreman/bookmark.rb
@@ -15,34 +15,34 @@ module HammerCLIForeman
         field :owner_type, _('Owner Type')
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand
       output ListCommand.output_definition
-      
-      build_options
+
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class CreateCommand < HammerCLIForeman::CreateCommand
       success_message _('Bookmark %<name>s created.')
       failure_message _('Failed to create %<name>s bookmark')
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
       success_message _('Bookmark %<name>s updated successfully.')
       failure_message _('Failed to update %<name>s bookmark')
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class DeleteCommand < HammerCLIForeman::DeleteCommand
       success_message _('Bookmark deleted successfully.')
       failure_message _('Failed to delete bookmark')
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_foreman/compute_profile.rb
+++ b/lib/hammer_cli_foreman/compute_profile.rb
@@ -9,7 +9,7 @@ module HammerCLIForeman
         field :id, _('Id')
         field :name, _('Name')
       end
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand
@@ -25,13 +25,13 @@ module HammerCLIForeman
           field :vm_attrs, _('VM attributes')
         end
       end
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class CreateCommand < HammerCLIForeman::CreateCommand
       success_message _('Compute profile created.')
       failure_message _('Could not create a compute profile')
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
@@ -40,7 +40,7 @@ module HammerCLIForeman
       validate_options do
         any(:option_name,:option_id).required
       end
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class DeleteCommand < HammerCLIForeman::DeleteCommand
@@ -49,7 +49,7 @@ module HammerCLIForeman
       validate_options do
         any(:option_name,:option_id).required
       end
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     lazy_subcommand('values', _("Create update and delete Compute profile values"),

--- a/lib/hammer_cli_foreman/config_group.rb
+++ b/lib/hammer_cli_foreman/config_group.rb
@@ -8,7 +8,7 @@ module HammerCLIForeman
         field :name, _("Name")
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand
@@ -16,28 +16,28 @@ module HammerCLIForeman
         HammerCLIForeman::References.puppetclasses(self)
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class CreateCommand < HammerCLIForeman::CreateCommand
       success_message _("Config group created.")
       failure_message _("Could not create the config group")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
       success_message _("Config group updated.")
       failure_message _("Could not update the config group")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class DeleteCommand < HammerCLIForeman::DeleteCommand
       success_message _("Config group has been deleted.")
       failure_message _("Could not delete the config group")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_foreman/mail_notification.rb
+++ b/lib/hammer_cli_foreman/mail_notification.rb
@@ -11,7 +11,7 @@ module HammerCLIForeman
         field :name, _("Name")
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand
@@ -22,7 +22,7 @@ module HammerCLIForeman
         field :subscription_type, _("Subscription type")
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_foreman/model.rb
+++ b/lib/hammer_cli_foreman/model.rb
@@ -13,7 +13,7 @@ module HammerCLIForeman
         field :hardware_model, _("HW model")
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -23,7 +23,7 @@ module HammerCLIForeman
         HammerCLIForeman::References.timestamps(self)
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -31,14 +31,14 @@ module HammerCLIForeman
       success_message _("Hardware model created.")
       failure_message _("Could not create the hardware model")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class DeleteCommand < HammerCLIForeman::DeleteCommand
       success_message _("Hardware model deleted.")
       failure_message _("Could not delete the hardware model")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -46,7 +46,7 @@ module HammerCLIForeman
       success_message _("Hardware model updated.")
       failure_message _("Could not update the hardware model")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 

--- a/lib/hammer_cli_foreman/operating_system.rb
+++ b/lib/hammer_cli_foreman/operating_system.rb
@@ -13,7 +13,7 @@ module HammerCLIForeman
         field :family, _("Family")
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -36,7 +36,7 @@ module HammerCLIForeman
         HammerCLIForeman::References.parameters(self)
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -44,7 +44,7 @@ module HammerCLIForeman
       success_message _("Operating system created.")
       failure_message _("Could not create the operating system")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -52,7 +52,7 @@ module HammerCLIForeman
       success_message _("Operating system updated.")
       failure_message _("Could not update the operating system")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -60,7 +60,7 @@ module HammerCLIForeman
       success_message _("Operating system deleted.")
       failure_message _("Could not delete the operating system")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -76,7 +76,7 @@ module HammerCLIForeman
         validator.any(:option_operatingsystem_id, :option_operatingsystem_title).required
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -90,7 +90,7 @@ module HammerCLIForeman
         validator.any(:option_operatingsystem_id, :option_operatingsystem_title).required
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 
@@ -156,7 +156,8 @@ module HammerCLIForeman
         HammerCLI::EX_OK
       end
 
-      build_options :without => [:template_kind_id, :type]
+      build_options expand: { except: %i[organizations locations] },
+                    without: %i[organization_id location_id template_kind_id type]
     end
 
 
@@ -191,7 +192,7 @@ module HammerCLIForeman
         {"operatingsystem_id" => option_id}
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 

--- a/lib/hammer_cli_foreman/settings.rb
+++ b/lib/hammer_cli_foreman/settings.rb
@@ -20,7 +20,7 @@ module HammerCLIForeman
         data
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
@@ -29,7 +29,7 @@ module HammerCLIForeman
       success_message _("Setting [%{name}] updated to [%{value}].")
       failure_message _("Could not update the setting")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand
@@ -42,7 +42,7 @@ module HammerCLIForeman
         field :value, _("Value")
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
 

--- a/lib/hammer_cli_foreman/usergroup.rb
+++ b/lib/hammer_cli_foreman/usergroup.rb
@@ -13,7 +13,7 @@ module HammerCLIForeman
         field :admin, _("Admin"), Fields::Boolean
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand
@@ -25,28 +25,28 @@ module HammerCLIForeman
         HammerCLIForeman::References.timestamps(self)
       end
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class CreateCommand < HammerCLIForeman::CreateCommand
       success_message _("User group [%<name>s] created.")
       failure_message _("Could not create the user group")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
       success_message _("User group [%<name>s] updated.")
       failure_message _("Could not update the user group")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     class DeleteCommand < HammerCLIForeman::DeleteCommand
       success_message _("User group [%<name>s] deleted.")
       failure_message _("Could not delete the user group")
 
-      build_options
+      build_options expand: { except: %i[organizations locations] }, without: %i[organization_id location_id]
     end
 
     HammerCLIForeman::AssociatingCommands::Role.extend_command(self)

--- a/test/functional/architecture_test.rb
+++ b/test/functional/architecture_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe 'architecture' do
+  describe 'list' do
+    before do
+      @cmd = %w[architecture list]
+      @architectures = [{
+                      id: 1,
+                      name: 'i386',
+                    }]
+    end
+
+    it 'should return a list of architectures' do
+      api_expects(:architectures, :index, 'List architectures').returns(@architectures)
+
+      output = IndexMatcher.new([
+                                  %w[ID NAME],
+                                  %w[1 i386]
+                                ])
+      expected_result = success_result(output)
+
+      result = run_cmd(@cmd)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:architectures, :index, 'List architectures').returns(@architectures)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
+  end
+end
+

--- a/test/functional/bookmark_test.rb
+++ b/test/functional/bookmark_test.rb
@@ -27,6 +27,26 @@ describe 'bookmark' do
       result = run_cmd(@cmd)
       assert_cmd(expected_result, result)
     end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:bookmarks, :index, 'List bookmarks').returns(@bookmarks)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
   end
 
   describe 'info' do

--- a/test/functional/compute_profile_test.rb
+++ b/test/functional/compute_profile_test.rb
@@ -98,4 +98,47 @@ describe "parameters" do
     end
   end
 
+  describe 'list' do
+    before do
+      @cmd = %w[compute-profile list]
+      @compute_profiles = [{
+                          id: 1,
+                          name: '1-Small',
+                        }]
+    end
+
+    it 'should return a list of compute profiles' do
+      api_expects(:compute_profiles, :index, 'List compute profiles').returns(@compute_profiles)
+
+      output = IndexMatcher.new([
+                                  %w[ID NAME],
+                                  %w[1 1-Small]
+                                ])
+      expected_result = success_result(output)
+
+      result = run_cmd(@cmd)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:compute_profiles, :index, 'List compute profiles').returns(@compute_profiles)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
+  end
+
 end

--- a/test/functional/config_group_test.rb
+++ b/test/functional/config_group_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe 'config_group' do
+  describe 'list' do
+    before do
+      @cmd = %w[config-group list]
+      @config_groups = [{
+                          id: 1,
+                          name: 'config-group-test',
+                        }]
+    end
+
+    it 'should return a list of config groups' do
+      api_expects(:config_groups, :index, 'List config groups').returns(@config_groups)
+
+      output = IndexMatcher.new([
+                                  %w[ID NAME],
+                                  %w[1 config-group-test]
+                                ])
+      expected_result = success_result(output)
+
+      result = run_cmd(@cmd)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:config_groups, :index, 'List config groups').returns(@config_groups)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
+  end
+end
+
+

--- a/test/functional/host_test.rb
+++ b/test/functional/host_test.rb
@@ -425,7 +425,7 @@ describe 'host update' do
     )
     api_expects(:hosts, :update, 'Update host with new owner').with_params(
         'id' => '1', 'location_id' => 1, 'organization_id' => 1, 'host' => {
-        'owner_id' => '1' }
+          'owner_id' => '1' }
     ) do |par|
       par['id'] == '1' && par['host']['owner_id'] == '1'
     end.returns(updated_host)
@@ -459,7 +459,7 @@ end
 describe 'host config reports' do
   let(:report15) do
     {
-        "id" => 15,
+      "id" => 15,
         "host_id" => 1,
         "host_name" => "host.example.com",
         "reported_at" => "2017-11-13 03:04:53 UTC",
@@ -547,5 +547,33 @@ describe 'run puppetrun for host' do
 
     result = run_cmd(cmd)
     assert_cmd(expected_result, result)
+  end
+end
+
+describe 'list' do
+  before do
+    @cmd = %w[host list]
+  end
+
+  it 'should run list command with defaults' do
+    providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+    defaults = HammerCLI::Defaults.new(
+      {
+        organization_id: {
+          provider: 'foreman'
+        },
+        location_id: {
+          provider: 'foreman'
+        }
+      }
+    )
+    defaults.stubs(:write_to_file).returns(true)
+    defaults.stubs(:providers).returns(providers)
+    api_expects(:users, :index, 'Find user').with_params(search: 'login=admin').returns(index_response([{ 'default_organization' => { 'id' => 2 } }]))
+    api_expects(:users, :index, 'Find user').with_params(search: 'login=admin').returns(index_response([{ 'default_location' => { 'id' => 1 } }]))
+    api_expects(:hosts, :index, 'List hosts').returns(index_response([{ 'id' => '42' }]))
+
+    result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+    _(result.exit_code).must_equal HammerCLI::EX_OK
   end
 end

--- a/test/functional/mail_notification_test.rb
+++ b/test/functional/mail_notification_test.rb
@@ -24,6 +24,26 @@ describe 'mail_notification' do
       result = run_cmd(@cmd)
       assert_cmd(expected_result, result)
     end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:mail_notifications, :index, 'List mail notifications').returns(@mail_notifications)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
   end
 
   describe 'info' do

--- a/test/functional/model_test.rb
+++ b/test/functional/model_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe 'model' do
+  describe 'list' do
+    before do
+      @cmd = %w[model list]
+      @models = [{
+                          id: 1,
+                          name: 'model',
+                        }]
+    end
+
+    it 'should return a list of models' do
+      api_expects(:models, :index, 'List models').returns(@models)
+
+      output = IndexMatcher.new([
+                                  %w[ID NAME],
+                                  %w[1 model]
+                                ])
+      expected_result = success_result(output)
+
+      result = run_cmd(@cmd)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:models, :index, 'List models').returns(@models)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
+  end
+end
+
+

--- a/test/functional/operating_system_test.rb
+++ b/test/functional/operating_system_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe 'operating_system' do
+  describe 'list' do
+    before do
+      @cmd = %w[os list]
+      @operating_system = [{
+                          id: 1,
+                          release_name: 'Redhat 7',
+                          family: 'Redhat',
+                        }]
+    end
+
+    it 'should return a list of operating system' do
+      api_expects(:operatingsystems, :index, 'List operating systems').returns(@operating_system)
+
+      output = IndexMatcher.new([
+                                  ['ID', 'RELEASE NAME', 'FAMILY'],
+                                  ['1', 'Redhat 7', 'Redhat']
+                                ])
+      expected_result = success_result(output)
+
+      result = run_cmd(@cmd)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:operatingsystems, :index, 'List operating systems').returns(@operating_system)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
+  end
+end
+
+

--- a/test/functional/settings_test.rb
+++ b/test/functional/settings_test.rb
@@ -31,6 +31,27 @@ describe 'Settings' do
       assert_cmd(expected_result, result)
     end
 
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:settings, :index, 'List').with_params(
+        'page' => 1, 'per_page' => 1000
+      ).returns(index_response([setting]))
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
   end
 
   describe 'info' do

--- a/test/functional/usergroup_test.rb
+++ b/test/functional/usergroup_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe 'user-group' do
+  describe 'list' do
+    before do
+      @cmd = %w[user-group list]
+      @user_groups = [{
+                          id: 1,
+                          name: 'test-user-group',
+                          admin: 'yes',
+                        }]
+    end
+
+    it 'should return a list of user groups' do
+      api_expects(:usergroups, :index, 'List user groups').returns(@user_groups)
+
+      output = IndexMatcher.new([
+                                  %w[ID NAME ADMIN],
+                                  %w[1 test-user-group yes]
+                                ])
+      expected_result = success_result(output)
+
+      result = run_cmd(@cmd)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'should run list command with defaults' do
+      providers = { 'foreman' => HammerCLIForeman::Defaults.new(api_connection({}, '2.1')) }
+      defaults = HammerCLI::Defaults.new(
+        {
+          organization_id: {
+            provider: 'foreman'
+          },
+          location_id: {
+            provider: 'foreman'
+          }
+        }
+      )
+      defaults.stubs(:write_to_file).returns(true)
+      defaults.stubs(:providers).returns(providers)
+      api_expects(:usergroups, :index, 'List user groups').returns(@user_groups)
+
+      result = run_cmd(@cmd, { use_defaults: true, defaults: defaults })
+      _(result.exit_code).must_equal HammerCLI::EX_OK
+    end
+  end
+end
+
+

--- a/test/unit/apipie_resource_mock.rb
+++ b/test/unit/apipie_resource_mock.rb
@@ -237,6 +237,27 @@ module ResourceMocks
       )
   end
 
+  def self.bookmarks
+    ResourceMocks.mock_action_calls(
+      [:bookmarks, :index, []],
+      [:bookmarks, :show, {}]
+    )
+  end
+
+  def self.mail_notifications
+    ResourceMocks.mock_action_calls(
+      [:mail_notifications, :index, []],
+      [:mail_notifications, :show, {}]
+    )
+  end
+
+  def self.compute_profiles
+    ResourceMocks.mock_action_calls(
+      [:compute_profiles, :index, []],
+      [:compute_profiles, :show, {}]
+    )
+  end
+
   def self.parameters_index
     ResourceMocks.mock_action_call(:parameters, :index, [])
   end

--- a/test/unit/architecture_test.rb
+++ b/test/unit/architecture_test.rb
@@ -17,6 +17,8 @@ describe HammerCLIForeman::Architecture do
     context "parameters" do
       it_should_accept "no arguments"
       it_should_accept_search_params
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -37,6 +39,8 @@ describe HammerCLIForeman::Architecture do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "name", ["--name=arch"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "no arguments" # TODO: temporarily disabled, parameters are checked in the id resolver
     end
 
@@ -57,6 +61,8 @@ describe HammerCLIForeman::Architecture do
 
     context "parameters" do
       it_should_accept "name", ["--name=arch"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name missing", []
       # TODO: temporarily disabled, parameters are checked in the api
     end
@@ -71,6 +77,8 @@ describe HammerCLIForeman::Architecture do
     context "parameters" do
       it_should_accept "name", ["--name=arch"]
       it_should_accept "id", ["--id=1"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name or id missing", [] # TODO: temporarily disabled, parameters are checked in the id resolver
     end
 
@@ -84,9 +92,10 @@ describe HammerCLIForeman::Architecture do
     context "parameters" do
       it_should_accept "name", ["--name=arch", "--new-name=arch2"]
       it_should_accept "id", ["--id=1", "--new-name=arch2"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "no params", [] # TODO: temporarily disabled, parameters are checked in the id resolver
       # it_should_fail_with "name or id missing", ["--new-name=arch2"] # TODO: temporarily disabled, parameters are checked in the id resolver
     end
-
   end
 end

--- a/test/unit/bookmark_test.rb
+++ b/test/unit/bookmark_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
+
+require 'hammer_cli_foreman/bookmark'
+
+describe HammerCLIForeman::Bookmark do
+  include CommandTestHelper
+
+  context 'ListCommand' do
+    before :each do
+      ResourceMocks.bookmarks
+    end
+
+    let(:cmd) { HammerCLIForeman::Bookmark::ListCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'no arguments'
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+    context 'output' do
+      let(:expected_record_count) { count_records(cmd.resource.call(:index)) }
+
+      it_should_print_n_records
+      it_should_print_column 'Id'
+      it_should_print_column 'Name'
+      it_should_print_column 'Controller'
+      it_should_print_column 'Search Query'
+      it_should_print_column 'Public'
+      it_should_print_column 'Owner Id'
+      it_should_print_column 'Owner Type'
+    end
+  end
+
+  context 'InfoCommand' do
+    let(:cmd) { HammerCLIForeman::Bookmark::InfoCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'id', ['--id=1']
+      it_should_accept 'name', ['--name=active']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+    context 'output' do
+      with_params ['--id=1'] do
+        it_should_print_n_records 1
+        it_should_print_column 'Id'
+        it_should_print_column 'Name'
+        it_should_print_column 'Controller'
+        it_should_print_column 'Search Query'
+        it_should_print_column 'Public'
+        it_should_print_column 'Owner Id'
+        it_should_print_column 'Owner Type'
+      end
+    end
+  end
+
+  context 'CreateCommand' do
+    let(:cmd) { HammerCLIForeman::Bookmark::CreateCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'name, public, controller, query',
+                       ['--name=active', '--public=1', '--controller=hosts',
+                        '--query=last_report > "35 minutes ago" and (status.applied > 0 or status.restarted > 0)']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+  end
+
+  context 'DeleteCommand' do
+    let(:cmd) { HammerCLIForeman::Bookmark::DeleteCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'id', ['--id=1']
+      it_should_accept 'name', ['--name=active']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+  end
+
+  context 'UpdateCommand' do
+    let(:cmd) { HammerCLIForeman::Bookmark::UpdateCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'id', ['--id=1']
+      it_should_accept 'name', ['--name=active']
+      it_should_accept 'name, public, controller, query',
+                       ['--name=active', '--public=1', '--controller=hosts',
+                        '--query=last_report > "35 minutes ago" and (status.applied > 0 or status.restarted > 0)']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+  end
+end

--- a/test/unit/compute_profile_test.rb
+++ b/test/unit/compute_profile_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
+
+require 'hammer_cli_foreman/compute_profile'
+
+describe HammerCLIForeman::ComputeProfile do
+  include CommandTestHelper
+
+  context 'ListCommand' do
+    before :each do
+      ResourceMocks.compute_profiles
+    end
+
+    let(:cmd) { HammerCLIForeman::ComputeProfile::ListCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'no arguments'
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+    context 'output' do
+      let(:expected_record_count) { count_records(cmd.resource.call(:index)) }
+
+      it_should_print_n_records
+      it_should_print_column 'Id'
+      it_should_print_column 'Name'
+    end
+  end
+
+  context 'InfoCommand' do
+    let(:cmd) { HammerCLIForeman::ComputeProfile::InfoCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'id', ['--id=1']
+      it_should_accept 'name', ['--name=test']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+    context 'output' do
+      with_params ['--id=1'] do
+        it_should_print_n_records 1
+        it_should_print_column 'Id'
+        it_should_print_column 'Name'
+        it_should_print_column 'Created at'
+        it_should_print_column 'Updated at'
+        it_should_print_column 'Compute attributes'
+      end
+    end
+  end
+
+  context 'CreateCommand' do
+    let(:cmd) { HammerCLIForeman::ComputeProfile::CreateCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'name', ['--name=test']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+  end
+
+  context 'DeleteCommand' do
+    let(:cmd) { HammerCLIForeman::ComputeProfile::DeleteCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'id', ['--id=1']
+      it_should_accept 'name', ['--name=test']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+  end
+
+  context 'UpdateCommand' do
+    let(:cmd) { HammerCLIForeman::ComputeProfile::UpdateCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'id', ['--id=1']
+      it_should_accept 'name', ['--name=test']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+  end
+end

--- a/test/unit/config_group_test.rb
+++ b/test/unit/config_group_test.rb
@@ -16,6 +16,8 @@ describe HammerCLIForeman::ConfigGroup do
     context "parameters" do
       it_should_accept "no arguments"
       it_should_accept_search_params
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -31,6 +33,8 @@ describe HammerCLIForeman::ConfigGroup do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "name", ["--name=group_x"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -48,6 +52,8 @@ describe HammerCLIForeman::ConfigGroup do
 
     context "parameters" do
       it_should_accept "name, puppetclass ids", ["--name=first_group", "--puppet-class-ids=1,2"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
   end
 
@@ -57,6 +63,8 @@ describe HammerCLIForeman::ConfigGroup do
     context "parameters" do
       it_should_accept "name", ["--name=group_x"]
       it_should_accept "id", ["--id=1"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
   end
 
@@ -67,6 +75,8 @@ describe HammerCLIForeman::ConfigGroup do
     context "parameters" do
       it_should_accept "name", ["--name=group_x"]
       it_should_accept "id", ["--id=1"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
   end
 end

--- a/test/unit/mail_notification_test.rb
+++ b/test/unit/mail_notification_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require File.join(File.dirname(__FILE__), 'test_helper')
+require File.join(File.dirname(__FILE__), 'apipie_resource_mock')
+
+require 'hammer_cli_foreman/mail_notification'
+
+describe HammerCLIForeman::MailNotification do
+  include CommandTestHelper
+
+  context 'ListCommand' do
+    before :each do
+      ResourceMocks.mail_notifications
+    end
+
+    let(:cmd) { HammerCLIForeman::MailNotification::ListCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'no arguments'
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+    context 'output' do
+      let(:expected_record_count) { count_records(cmd.resource.call(:index)) }
+
+      it_should_print_n_records
+      it_should_print_column 'Id'
+      it_should_print_column 'Name'
+    end
+  end
+
+  context 'InfoCommand' do
+    let(:cmd) { HammerCLIForeman::MailNotification::InfoCommand.new('', ctx) }
+
+    context 'parameters' do
+      it_should_accept 'id', ['--id=1']
+      it_should_accept 'name', ['--name=test']
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
+    end
+
+    context 'output' do
+      with_params ['--id=1'] do
+        it_should_print_n_records 1
+        it_should_print_column 'Id'
+        it_should_print_column 'Name'
+        it_should_print_column 'Description'
+        it_should_print_column 'Subscription type'
+      end
+    end
+  end
+end

--- a/test/unit/model_test.rb
+++ b/test/unit/model_test.rb
@@ -17,6 +17,8 @@ describe HammerCLIForeman::Model do
     context "parameters" do
       it_should_accept "no arguments"
       it_should_accept_search_params
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -38,6 +40,8 @@ describe HammerCLIForeman::Model do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "name", ["--name=model"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "no arguments" # TODO: temporarily disabled, parameters are checked in the id resolver
     end
 
@@ -63,6 +67,8 @@ describe HammerCLIForeman::Model do
 
     context "parameters" do
       it_should_accept "name", ["--name=model", "--info=description", "--vendor-class=class", "--hardware-model=model"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name missing", ["--info=description", "--vendor-class=class", "--hardware-model=model"]
       # TODO: temporarily disabled, parameters are checked in the api
     end
@@ -77,6 +83,8 @@ describe HammerCLIForeman::Model do
     context "parameters" do
       it_should_accept "name", ["--name=model"]
       it_should_accept "id", ["--id=1"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name or id missing", [] # TODO: temporarily disabled, parameters are checked in the id resolver
     end
 
@@ -90,6 +98,8 @@ describe HammerCLIForeman::Model do
     context "parameters" do
       it_should_accept "name", ["--name=model", "--new-name=model2", "--info=description", "--vendor-class=class", "--hardware-model=model"]
       it_should_accept "id", ["--id=1", "--new-name=model2", "--info=description", "--vendor-class=class", "--hardware-model=model"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "no params", []
       # it_should_fail_with "name or id missing", ["--new-name=model2", "--info=description", "--vendor-class=class", "--hardware-model=model"]
       # TODO: temporarily disabled, parameters are checked in the id resolver

--- a/test/unit/operating_system_test.rb
+++ b/test/unit/operating_system_test.rb
@@ -18,6 +18,8 @@ describe HammerCLIForeman::OperatingSystem do
     context "parameters" do
       it_should_accept "no arguments"
       it_should_accept_search_params
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -40,6 +42,8 @@ describe HammerCLIForeman::OperatingSystem do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "title", ["--title=Rhel 6.5"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "no arguments" # TODO: temporarily disabled, parameters are checked in the id resolver
     end
 
@@ -70,6 +74,8 @@ describe HammerCLIForeman::OperatingSystem do
 
     context "parameters" do
       it_should_accept "name, major, minor, family, release name", ["--name=media", "--major=1", "--minor=2", "--family=Red Hat", "--release-name=awesome"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name missing", ["--major=1", "--minor=2", "--family=Red Hat", "--release-name=awesome"]
       # TODO: temporarily disabled, parameters are checked in the api
     end
@@ -87,6 +93,8 @@ describe HammerCLIForeman::OperatingSystem do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "title", ["--title=Rhel 6.5"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name or id missing", [] # TODO: temporarily disabled, parameters are checked in the id resolver
       # TODO: temporarily disabled, parameters are checked in the id resolver
     end
@@ -102,6 +110,8 @@ describe HammerCLIForeman::OperatingSystem do
       it_should_accept "id", ["--id=1"]
       it_should_accept "title", ["--title=Rhel 6.5"]
       it_should_accept "name, major, minor, family, release name", ["--id=83", "--name=os", "--major=1", "--minor=2", "--family=Red Hat", "--release-name=awesome"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "no params", []
       # it_should_fail_with "label or id missing", ["--name=os", "--major=1", "--minor=2", "--family=Red Hat", "--release-name=awesome"]
       # TODO: temporarily disabled, parameters are checked in the id resolver
@@ -126,6 +136,8 @@ describe HammerCLIForeman::OperatingSystem do
       it_should_accept "name, value and os id", ["--name=domain", "--value=val", "--operatingsystem-id=1"]
       it_should_accept "name, value and os title", ["--name=domain", "--value=val", "--operatingsystem=Rhel 6.5"]
       it_should_accept "name, value, type and os id", ["--name=domain", "--value=val", "--parameter-type=string", "--operatingsystem-id=1"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name missing", ["--value=val", "--operatingsystem-id=id"]
       # it_should_fail_with "value missing", ["--name=name", "--operatingsystem-id=id"]
       # it_should_fail_with "os id missing", ["--name=name", "--value=val"]
@@ -142,11 +154,12 @@ describe HammerCLIForeman::OperatingSystem do
     context "parameters" do
       it_should_accept "name and os id", ["--name=domain", "--operatingsystem-id=1"]
       it_should_accept "name and os title", ["--name=domain", "--operatingsystem=Rhel 6.5"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
       # it_should_fail_with "name missing", ["--operatingsystem-id=id"]
       # it_should_fail_with "os id missing", ["--name=name"]
       # TODO: temporarily disabled, parameters are checked in the id resolver
     end
 
   end
-
 end

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -18,6 +18,8 @@ describe HammerCLIForeman::Settings do
     context "parameters" do
       it_should_accept "no arguments"
       it_should_accept_search_params
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -38,6 +40,8 @@ describe HammerCLIForeman::Settings do
     context "parameters" do
       it_should_accept "name", ["--name=setting1", "--value=setting2"]
       it_should_accept "id", ["--id=1", "--value=setting2"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
   end

--- a/test/unit/usergroup_test.rb
+++ b/test/unit/usergroup_test.rb
@@ -18,6 +18,8 @@ describe HammerCLIForeman::Usergroup do
     context "parameters" do
       it_should_accept "no arguments"
       it_should_accept_search_params
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -35,6 +37,8 @@ describe HammerCLIForeman::Usergroup do
     context "parameters" do
       it_should_accept "id", ["--id=1"]
       it_should_accept "name", ["--name=ug"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
 
     context "output" do
@@ -58,6 +62,8 @@ describe HammerCLIForeman::Usergroup do
     context "parameters" do
       it_should_accept "name", ["--name=ug"]
       it_should_accept "name, role ids, user group ids and user ids", ["--name=ug", "--role-ids=1,2,3", "--user-group-ids=1,2,3", "--user-ids=1,2,3"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
   end
 
@@ -68,6 +74,8 @@ describe HammerCLIForeman::Usergroup do
     context "parameters" do
       it_should_accept "name", ["--name=ug"]
       it_should_accept "id", ["--id=1"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
   end
 
@@ -80,6 +88,8 @@ describe HammerCLIForeman::Usergroup do
       it_should_accept "id", ["--id=1"]
       it_should_accept "name and new name", ["--name=ug", "--new-name=ug2"]
       it_should_accept "id, new name, role ids, user group ids and user ids", ["--id=1", "--new-name=ug", "--role-ids=1,2,3", "--user-group-ids=1,2,3", "--user-ids=1,2,3"]
+      it_should_fail_with 'organization param', ['--organization-id=1']
+      it_should_fail_with 'location param', ['--location-id=1']
     end
   end
 end


### PR DESCRIPTION
This fix is for a few commands that were failing whenever running list
if defaults were set before.