### PR TITLE
fixes #31536 - Removing puppetrun command

### DIFF
--- a/lib/hammer_cli_foreman/host.rb
+++ b/lib/hammer_cli_foreman/host.rb
@@ -176,8 +176,9 @@ module HammerCLIForeman
       resource :puppet_hosts
       action :puppetrun
 
-      def print_data(records)
-        print_message _('Puppet run triggered')
+      def execute
+        warn _('The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands')
+        HammerCLI::EX_SOFTWARE
       end
 
       build_options

--- a/test/functional/host_test.rb
+++ b/test/functional/host_test.rb
@@ -502,3 +502,17 @@ describe 'disassociate host from vm' do
     assert_cmd(expected_result, result)
   end
 end
+
+describe 'run puppetrun for host' do
+  let(:cmd) { ['host', 'puppetrun'] }
+  let(:params) { ['--id=1'] }
+
+  it "does nothing for puppetrun" do
+    expected_result = CommandExpectation.new
+    expected_result.expected_err = "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands\n"
+    expected_result.expected_exit_code = HammerCLI::EX_SOFTWARE
+
+    result = run_cmd(cmd)
+    assert_cmd(expected_result, result)
+  end
+end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -132,29 +132,6 @@ describe HammerCLIForeman::Host do
   end
 
 
-  context "PuppetRunCommand" do
-
-    let(:cmd) { HammerCLIForeman::Host::PuppetRunCommand.new("", ctx) }
-
-    context "parameters" do
-      it_should_accept "name", ["--name=host"]
-      it_should_accept "id", ["--id=1"]
-      # it_should_fail_with "no arguments"
-      # TODO: temporarily disabled, parameters are checked in the id resolver
-
-    end
-
-    context "output" do
-      with_params ["--id=1"] do
-        it "should inform that puppet was triggered" do
-          cmd.stubs(:context).returns(ctx.update(:adapter => :test))
-          _(proc { cmd.run(with_params) }).must_output "Puppet run triggered\n"
-        end
-      end
-    end
-  end
-
-
   context "ConfigReportsCommand" do
     before do
       ResourceMocks.mock_action_call(:config_reports, :index, [])


### PR DESCRIPTION
Since the puppetrun is deprecated and removed, this PR removes command that invokes non-existing puppetrun command at Foreman side