### PR TITLE
Fixes #8923 - Add kerberos negotiate auth support

### DIFF
--- a/config/foreman.yml
+++ b/config/foreman.yml
@@ -29,6 +29,10 @@
   #:oidc_client_id: example-client-id
   #:oidc_redirect_uri: urn:ietf:wg:oauth:2.0:oob
 
+  # Negotiate (Kerberos) Auth:
+  # User needs to run kinit before using hammer (or initiate kerberos keyring in another way).
+  #:default_auth_type: 'Negotiate_Auth'
+
   # Enable using sessions
   # When sessions are enabled, hammer ignores credentials stored in the config file
   # and asks for them interactively at the begining of each session.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -49,3 +49,33 @@ Please note that when you turn sessions on, the credentials stored in your confi
 
 The default session timeout is 1 hour. This can be changed in the Foreman: `Settings > Authentication > Idle timeout`
 When the session expires hammer will prompt for username and password again.
+
+### Negotiate (Kerberos) auth
+
+This implements Kerberos authentication, usually implemented in FreeIPA or Microsoft Active Directory.
+For this to work, the host that we are trying to use hammer on, needs to have realm already configured on this host.
+This can be achieved through `realm join`, please refer to that command for more info.
+
+**Sessions needs to be enabled**
+
+`~/.hammer/cli.modules.d/foreman.yml`
+```yaml
+:foreman:
+  :default_auth_type: 'Negotiate_Auth'
+  :use_sessions: true
+```
+
+```bash
+# To initiate the kerberos keyring (this might be already done on login)
+$ kinit <kerb_user>
+# Enter your password
+$ klist
+Ticket cache: KEYRING:persistent:1000:1000
+Default principal: kerb_user@REALM.EXAMPLE.COM
+
+# use hammer as usuall, it will negotiate your auth on the first request
+hammer ...
+
+# or if you do not have negotiate as default auth, initiate the auth manually
+hammer auth login negotiate
+```

--- a/lib/hammer_cli_foreman/api/authenticator.rb
+++ b/lib/hammer_cli_foreman/api/authenticator.rb
@@ -13,6 +13,8 @@ module HammerCLIForeman
           void_auth
         elsif auth_type == AUTH_TYPES[:basic_auth]
           basic_auth
+        elsif auth_type == AUTH_TYPES[:negotiate]
+          negotiate_auth
         elsif auth_type == AUTH_TYPES[:oauth_password_grant]
           oauth_password_grant
         elsif auth_type == AUTH_TYPES[:oauth_authentication_code_grant]
@@ -41,6 +43,13 @@ module HammerCLIForeman
           end
           InteractiveBasicAuth.new(username, password)
         end
+      end
+
+      def negotiate_auth
+        return unless HammerCLIForeman::Sessions.enabled?
+
+        authenticator = NegotiateAuth.new(uri)
+        SessionAuthenticatorWrapper.new(authenticator, uri, auth_type)
       end
 
       def oauth_password_grant

--- a/lib/hammer_cli_foreman/api/connection.rb
+++ b/lib/hammer_cli_foreman/api/connection.rb
@@ -1,6 +1,7 @@
 require 'hammer_cli_foreman/api/session_authenticator_wrapper'
 require 'hammer_cli_foreman/api/authenticator'
 require 'hammer_cli_foreman/api/interactive_basic_auth'
+require 'hammer_cli_foreman/api/negotiate_auth'
 require 'hammer_cli_foreman/api/oauth/authentication_code_grant'
 require 'hammer_cli_foreman/api/oauth/password_grant'
 require 'hammer_cli_foreman/api/void_auth'
@@ -10,6 +11,7 @@ module HammerCLIForeman
   CONNECTION_NAME = 'foreman'
   AUTH_TYPES = {
     basic_auth: 'Basic_Auth',
+    negotiate: 'Negotiate_Auth',
     oauth_authentication_code_grant: 'Oauth_Authentication_Code_Grant',
     oauth_password_grant: 'Oauth_Password_Grant'
   }.freeze

--- a/lib/hammer_cli_foreman/api/negotiate_auth.rb
+++ b/lib/hammer_cli_foreman/api/negotiate_auth.rb
@@ -1,0 +1,13 @@
+module HammerCLIForeman
+  module Api
+    class NegotiateAuth < ApipieBindings::Authenticators::Negotiate
+      def initialize(foreman_url, **options)
+        super("#{foreman_url}/users/extlogin", HammerCLI::SSLOptions.new.get_options(foreman_url).merge(options))
+      end
+
+      def user
+        'UNKNOWN'
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/api/negotiate_auth.rb
+++ b/lib/hammer_cli_foreman/api/negotiate_auth.rb
@@ -14,14 +14,11 @@ module HammerCLIForeman
       end
 
       def status
-        active = `klist` && $?.exitstatus.zero?
-        no_kerberos_session_msg = _('There is no active Kerberos session. Have you run %s?') % 'kinit'
-        return no_kerberos_session_msg unless active
-
-        _('No session, but there is an active Kerberos session, that will be used for negotiate login.')
-      rescue => e
-        Logging.logger['NegotiateAuth'].debug e
-        no_kerberos_session_msg
+        if system('klist')
+          _('No session, but there is an active Kerberos session, that will be used for negotiate login.')
+        else
+          _('There is no active Kerberos session. Have you run %s?') % 'kinit'
+        end
       end
 
       def error(ex)

--- a/lib/hammer_cli_foreman/api/negotiate_auth.rb
+++ b/lib/hammer_cli_foreman/api/negotiate_auth.rb
@@ -6,7 +6,18 @@ module HammerCLIForeman
       end
 
       def user
-        'UNKNOWN'
+        _('current Kerberos user')
+      end
+
+      def status
+        active = `klist` && $?.exitstatus.zero?
+        no_kerberos_session_msg = _('There is no active Kerberos session. Have you run %s?') % 'kinit'
+        return no_kerberos_session_msg unless active
+
+        _('No session, but there is an active Kerberos session, that will be used for negotiate login.')
+      rescue => e
+        Logging.logger['NegotiateAuth'].debug e
+        no_kerberos_session_msg
       end
     end
   end

--- a/lib/hammer_cli_foreman/api/negotiate_auth.rb
+++ b/lib/hammer_cli_foreman/api/negotiate_auth.rb
@@ -23,6 +23,17 @@ module HammerCLIForeman
         Logging.logger['NegotiateAuth'].debug e
         no_kerberos_session_msg
       end
+
+      def error(ex)
+        if ex.is_a?(RestClient::Unauthorized)
+          message = _('Invalid username or password.')
+          begin
+            message = JSON.parse(ex.response.body)['error']['message']
+          rescue
+          end
+          UnauthorizedError.new(message)
+        end
+      end
     end
   end
 end

--- a/lib/hammer_cli_foreman/api/negotiate_auth.rb
+++ b/lib/hammer_cli_foreman/api/negotiate_auth.rb
@@ -22,14 +22,14 @@ module HammerCLIForeman
       end
 
       def error(ex)
-        if ex.is_a?(RestClient::Unauthorized)
-          message = _('Invalid username or password.')
-          begin
-            message = JSON.parse(ex.response.body)['error']['message']
-          rescue
-          end
-          UnauthorizedError.new(message)
+        super unless ex.is_a?(RestClient::Unauthorized)
+
+        message = _('Invalid username or password.')
+        begin
+          message = JSON.parse(ex.response.body)['error']['message']
+        rescue
         end
+        UnauthorizedError.new(message)
       end
     end
   end

--- a/lib/hammer_cli_foreman/api/negotiate_auth.rb
+++ b/lib/hammer_cli_foreman/api/negotiate_auth.rb
@@ -9,6 +9,10 @@ module HammerCLIForeman
         _('current Kerberos user')
       end
 
+      def session_id
+        auth_cookie&.delete_prefix('_session_id=')
+      end
+
       def status
         active = `klist` && $?.exitstatus.zero?
         no_kerberos_session_msg = _('There is no active Kerberos session. Have you run %s?') % 'kinit'

--- a/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
+++ b/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
@@ -24,6 +24,8 @@ module HammerCLIForeman
       def status
         if session.valid?
           _("Session exists, currently logged in as '%s'.") % session.user_name
+        elsif @authenticator.respond_to?(:status)
+          @authenticator.status
         else
           _('Using sessions, you are currently not logged in.')
         end

--- a/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
+++ b/lib/hammer_cli_foreman/api/session_authenticator_wrapper.rb
@@ -68,8 +68,10 @@ module HammerCLIForeman
       end
 
       def response(r)
-        if (r.cookies['_session_id'] && r.code != 401)
-          session.id = r.cookies['_session_id']
+        session_id = @authenticator.session_id if @authenticator.respond_to?(:session_id)
+        session_id ||= r.cookies['_session_id']
+        if session_id && r.code != 401
+          session.id = session_id
           session.user_name = @authenticator.user
           session.store
         end

--- a/lib/hammer_cli_foreman/auth.rb
+++ b/lib/hammer_cli_foreman/auth.rb
@@ -28,6 +28,19 @@ module HammerCLIForeman
         end
       end
 
+      class Negotiate < HammerCLI::AbstractCommand
+        extend HammerCLIForeman::Authenticate::Login
+
+        command_name('negotiate')
+        desc('negotiate the login credentials from the auth ticket (Kerberos)')
+
+        def execute
+          Negotiate.execute_with_params(AUTH_TYPES[:negotiate])
+          print_message(_("Successfully authenticated using negotiate auth, using the KEYRING principal."))
+          HammerCLI::EX_OK
+        end
+      end
+
       class Oauth < HammerCLI::AbstractCommand
         extend HammerCLIForeman::Authenticate::Login
 

--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -156,8 +156,17 @@ module HammerCLIForeman
 
     def authenticator_error_message(e)
       case e.type
-      when :negotiate
-        _('Could not authenticate using negotiation protocol') + "\n  - " +
+      when :negotiate then negotiation_error_message(e)
+      end
+    end
+
+    def negotiation_error_message(e)
+      case e.code
+      when 302
+        _('Misconfiguration detected') + "\n  - " +
+          _('have you run installer with option %s?') % '--foreman-ipa-authentication=true' + "\n"
+      else
+        _('Could not authenticate using negotiation protocol') +
           _('have you run %s (for Kerberos)?') % 'kinit' + "\n  - " +
           _('is the server down?') + "\n"
       end

--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -158,7 +158,8 @@ module HammerCLIForeman
       case e.type
       when :negotiate
         _('Could not authenticate using negotiation protocol') + "\n  - " +
-          _('have you run %s (for Kerberos)?') % 'kinit' + "\n"
+          _('have you run %s (for Kerberos)?') % 'kinit' + "\n  - " +
+          _('is the server down?') + "\n"
       end
     end
 

--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -161,12 +161,12 @@ module HammerCLIForeman
     end
 
     def negotiation_error_message(e)
-      case e.code
-      when 302
-        _('Misconfiguration detected') + "\n  - " +
+      case e.cause
+      when :configuration
+        _('Server misconfiguration detected') + "\n  - " +
           _('have you run installer with option %s?') % '--foreman-ipa-authentication=true' + "\n"
       else
-        _('Could not authenticate using negotiation protocol') +
+        _('Could not authenticate using negotiation protocol') + "\n  - " +
           _('have you run %s (for Kerberos)?') % 'kinit' + "\n  - " +
           _('is the server down?') + "\n"
       end

--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -164,7 +164,8 @@ module HammerCLIForeman
       case e.cause
       when :configuration
         _('Server misconfiguration detected') + "\n  - " +
-          _('have you run installer with option %s?') % '--foreman-ipa-authentication=true' + "\n"
+          _('have you run installer with option %s?') % '--foreman-ipa-authentication=true' + "\n  - " +
+          _('the user might come from a different authentication source') + "\n"
       else
         _('Could not authenticate using negotiation protocol') + "\n  - " +
           _('have you run %s (for Kerberos)?') % 'kinit' + "\n  - " +


### PR DESCRIPTION
Implements negotiate authentication.
Doesnt support username output.

Depends on https://github.com/Apipie/apipie-bindings/pull/81.

Expects the host hammer to be in the same REALM as Foreman server and have Foreman external authentication enabled.
User needs to manually run `kinit`, if the user is not REALM user or/and doesnt have kerberos initialization enabled by default.
If `kinit` has not been run - and thus the ticket is not in local keyring, gssapi will fail in not very user friendly manner (help wanted, but I believe this is usable already, so can be merged without it).
I do not validate foreman being able to use negotiate - it will simply fail again `^^`.

If help with testing needed, let me know.