### PR TITLE
Fixes #32454 - Show new msg for empty update commands

### DIFF
--- a/lib/hammer_cli_foreman/command_extensions.rb
+++ b/lib/hammer_cli_foreman/command_extensions.rb
@@ -1,3 +1,4 @@
+require 'hammer_cli_foreman/command_extensions/update_common'
 require 'hammer_cli_foreman/command_extensions/fields'
 require 'hammer_cli_foreman/command_extensions/puppet_environment'
 require 'hammer_cli_foreman/command_extensions/puppet_environments'

--- a/lib/hammer_cli_foreman/command_extensions/update_common.rb
+++ b/lib/hammer_cli_foreman/command_extensions/update_common.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module HammerCLIForeman
+  module CommandExtensions
+    class UpdateCommon < HammerCLI::CommandExtensions
+      inheritable true
+
+      request_params do |params, command_object|
+        update_params = params[command_object.resource.singular_name]
+        command_object.context[:action_message] = :nothing_to_do if update_params && update_params.empty?
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/commands.rb
+++ b/lib/hammer_cli_foreman/commands.rb
@@ -548,6 +548,19 @@ module HammerCLIForeman
       builder
     end
 
+    def self.inherited(child)
+      child.success_message_for(:nothing_to_do, _('Nothing to update.'))
+    end
+
+    def clean_up_context
+      super
+      context.delete(:action_message)
+    end
+
+    def success_message
+      success_message_for(context[:action_message] || :default)
+    end
+
     def method_options_for_params(params, options)
       opts = super
       # overwrite searchables with correct values
@@ -560,6 +573,7 @@ module HammerCLIForeman
       opts
     end
 
+    extend_with(HammerCLIForeman::CommandExtensions::UpdateCommon.new)
   end
 
 

--- a/test/functional/architecture_test.rb
+++ b/test/functional/architecture_test.rb
@@ -45,5 +45,35 @@ describe 'architecture' do
       _(result.exit_code).must_equal HammerCLI::EX_OK
     end
   end
-end
 
+  describe 'update' do
+    before do
+      @cmd = %w[architecture update]
+      @architecture = {
+        id: 1,
+        name: 'x86_64',
+      }
+    end
+
+    it 'should update an architecture with id' do
+      params = %w[--id=1 --new-name=x86_64]
+      api_expects(:architectures, :update, 'Update architecture').returns(@architecture)
+
+      expected_result = success_result("Architecture updated.\n")
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(expected_result, result)
+    end
+
+    it 'updates nothing without architecture related parameters' do
+      params = %w[--id=1]
+      api_expects(:architectures, :update, 'Update architecture with no params').returns({})
+
+      expected_result = success_result("Nothing to update.\n")
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(expected_result, result)
+    end
+
+  end
+end

--- a/test/functional/bookmark_test.rb
+++ b/test/functional/bookmark_test.rb
@@ -158,7 +158,8 @@ describe 'bookmark' do
         api_expects(:bookmarks, :update) do |par|
           par['id'] == '1'
         end
-        run_cmd(%w[bookmark update --id 1])
+        result = run_cmd(%w[bookmark update --id 1])
+        assert_cmd(success_result("Nothing to update.\n"), result)
       end
 
       it 'update bookmark' do

--- a/test/functional/compute_profile_test.rb
+++ b/test/functional/compute_profile_test.rb
@@ -40,6 +40,17 @@ describe "parameters" do
       result = run_cmd(@cmd + params)
       assert_cmd(success_result("Compute profile updated.\n"), result)
     end
+
+    it 'updates nothing without profile related parameters' do
+      params = %w[--id=1]
+      api_expects(:compute_profiles, :update, 'Update profile with no params').returns({})
+
+      expected_result = success_result("Nothing to update.\n")
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(expected_result, result)
+    end
+
   end
 
   describe "delete compute profile" do

--- a/test/functional/host_test.rb
+++ b/test/functional/host_test.rb
@@ -404,7 +404,7 @@ describe 'host update' do
   it 'updates nothing without host related parameters' do
     api_expects(:hosts, :update, 'Update host with no host params').returns({})
 
-    expected_result = success_result("Host updated.\n")
+    expected_result = success_result("Nothing to update.\n")
 
     result = run_cmd(cmd + minimal_params)
     assert_cmd(expected_result, result)

--- a/test/functional/http_proxy_test.rb
+++ b/test/functional/http_proxy_test.rb
@@ -61,9 +61,21 @@ describe 'httpproxy' do
   end
 
   it 'deletes an http proxy' do
+    api_expects(:http_proxies, :destroy, 'Delete proxy').returns(http_proxy)
+
     expected_result = success_result("Http proxy deleted.\n")
 
     result = run_cmd(%w(http-proxy delete --id 1))
     assert_cmd(expected_result, result)
   end
+
+  it 'updates nothing without related parameters' do
+    api_expects(:http_proxies, :update, 'Update proxy with no params').returns({})
+
+    expected_result = success_result("Nothing to update.\n")
+
+    result = run_cmd(%w(http-proxy update --id 1))
+    assert_cmd(expected_result, result)
+  end
+
 end

--- a/test/functional/location_test.rb
+++ b/test/functional/location_test.rb
@@ -272,4 +272,17 @@ describe 'update' do
     result = run_cmd(@cmd + params)
     assert_cmd(success_result("Location updated.\n"), result)
   end
+
+  it 'updates nothing without related parameters' do
+    params = %w[--id=1]
+
+    api_expects(:locations, :index)
+    api_expects(:locations, :update, 'Update location with no params').returns({})
+
+    expected_result = success_result("Nothing to update.\n")
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
 end

--- a/test/functional/media_test.rb
+++ b/test/functional/media_test.rb
@@ -126,5 +126,16 @@ describe 'medium' do
       result = run_cmd(@cmd + params)
       assert_cmd(success_result("Installation medium updated.\n"), result)
     end
+
+    it 'updates nothing without medium related parameters' do
+      params = %w[--id=1]
+
+      api_expects(:media, :update, 'Update medium with no params').returns({})
+
+      expected_result = success_result("Nothing to update.\n")
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(expected_result, result)
+    end
   end
 end

--- a/test/functional/realm_test.rb
+++ b/test/functional/realm_test.rb
@@ -99,5 +99,16 @@ describe 'realm' do
       result = run_cmd(@cmd + params)
       assert_cmd(success_result("Realm [%{name}] updated.\n"), result)
     end
+
+    it 'updates nothing without realm related parameters' do
+      params = %w[--id=1]
+
+      api_expects(:realms, :update, 'Update realm with no params').returns({})
+
+      expected_result = success_result("Nothing to update.\n")
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(expected_result, result)
+    end
   end
 end

--- a/test/functional/report_template_test.rb
+++ b/test/functional/report_template_test.rb
@@ -195,6 +195,17 @@ describe 'report-template' do
       result = run_cmd(cmd + params)
       assert_cmd(success_result("Report template updated.\n"), result)
     end
+
+    it 'updates nothing without template related parameters' do
+      params = %w[--id=1]
+
+      api_expects(:report_templates, :update, 'Update template with no params').returns({})
+
+      expected_result = success_result("Nothing to update.\n")
+
+      result = run_cmd(cmd + params)
+      assert_cmd(expected_result, result)
+    end
   end
 
   describe 'dump' do

--- a/test/functional/template_test.rb
+++ b/test/functional/template_test.rb
@@ -95,6 +95,18 @@ describe 'template' do
 
       assert_cmd(success_result("Provisioning template updated.\n"), result)
     end
+
+    it 'updates nothing without template related parameters' do
+      params = %w[--id=1 --organization-id=1 --location-id=1]
+
+      api_expects(:template_kinds, :index, 'Get list of template kinds').returns(index_response([]))
+      api_expects(:provisioning_templates, :update, 'Update template with no params').returns({})
+
+      expected_result = success_result("Nothing to update.\n")
+
+      result = run_cmd(@cmd + params)
+      assert_cmd(expected_result, result)
+    end
   end
 
   describe 'create' do

--- a/test/functional/user_test.rb
+++ b/test/functional/user_test.rb
@@ -82,6 +82,17 @@ describe "user" do
       assert_cmd(expected_result, result)
     end
 
+    it 'updates nothing without user related parameters' do
+      params = %w[--id=1]
+
+      api_expects(:users, :update, 'Update user with no params').returns({})
+
+      expected_result = success_result("Nothing to update.\n")
+
+      result = run_cmd(cmd + params)
+      assert_cmd(expected_result, result)
+    end
+
     describe "update password" do
       def replace_foreman_connection(connection)
         HammerCLI.context[:api_connection].drop('foreman')


### PR DESCRIPTION
requires https://github.com/theforeman/hammer-cli/pull/343

Most of the update commands follow API docs and put resource related params under `resource` key in `request_params`. Thanks to this, we can simply check if anything is being put there and show `Nothing to update` message if not.