### PR TITLE
Fixes #32392 - Force name resolving due defaults

### DIFF
--- a/lib/hammer_cli_foreman/option_sources/id_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/id_params.rb
@@ -13,22 +13,39 @@ module HammerCLIForeman
         IdParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action))
       end
 
-      def get_options(defined_options, result)
+      def needs_resolving?(param_option, param_resource, all_opts)
+        return false unless param_updatable?(param_resource)
+
+        searchables_set = @command.searchables.for(param_resource).any? do |s|
+          option = HammerCLI.option_accessor_name("#{param_resource.singular_name}_#{s.name}")
+          !all_opts[option].nil?
+        end
+        return all_opts[param_option].nil? unless searchables_set
+
+        # Remove set '<resource_name>_id' option to force resolving in case of
+        # '<resource_name>_[name|title]' was set
+        all_opts.delete(param_option)
+        true
+      end
+
+      def get_options(_defined_options, result)
         # resolve all '<resource_name>_id' parameters if they are defined as options
         # (they can be skipped using .without or .expand.except)
         return result if @command.action.nil?
+
         available_id_params.each do |api_param|
           param_resource = HammerCLIForeman.param_to_resource(api_param.name)
-          if result[HammerCLI.option_accessor_name(api_param.name)].nil? && param_updatable?(param_resource)
-            resource_id = @command.get_resource_id(param_resource, :scoped => true, :required => api_param.required?, :all_options => result)
-            result[HammerCLI.option_accessor_name(api_param.name)] = resource_id if resource_id
-          end
+          param_option = HammerCLI.option_accessor_name(api_param.name)
+          next unless needs_resolving?(param_option, param_resource, result)
+
+          resource_id = @command.get_resource_id(
+            param_resource, scoped: true, required: api_param.required?, all_options: result
+          )
+          result[param_option] = resource_id if resource_id
         end
         result
-
       rescue HammerCLIForeman::MissingSearchOptions => e
-
-        switches = @command.class.find_options(:referenced_resource => e.resource.singular_name).map(&:long_switch)
+        switches = @command.class.find_options(referenced_resource: e.resource.singular_name).map(&:long_switch)
 
         if switches.empty?
           error_message = _("Could not find %{resource}. Some search options were missing, please see --help.")
@@ -40,8 +57,8 @@ module HammerCLIForeman
 
         raise MissingSearchOptions.new(
           error_message % {
-            :resource => e.resource.singular_name,
-            :switches => switches.join(", ")
+            resource: e.resource.singular_name,
+            switches: switches.join(', ')
           },
           e.resource
         )

--- a/lib/hammer_cli_foreman/option_sources/ids_params.rb
+++ b/lib/hammer_cli_foreman/option_sources/ids_params.rb
@@ -13,15 +13,34 @@ module HammerCLIForeman
         IdArrayParamsFilter.new(:only_required => false).for_action(@command.resource.action(@command.action))
       end
 
-      def get_options(defined_options, result)
-        return result if @command.action.nil?
+      def needs_resolving?(param_option, param_resource, all_opts)
+        return false unless param_updatable?(param_resource)
+
+        searchables_set = @command.searchables.for(param_resource).any? do |s|
+          option = HammerCLI.option_accessor_name("#{param_resource.singular_name}_#{s.plural_name}")
+          !all_opts[option].nil?
+        end
+        return all_opts[param_option].nil? unless searchables_set
+
+        # Remove set '<resource_name>_ids' option to force resolving in case of
+        # '<resource_name>_[names|titles]' was set
+        all_opts.delete(param_option)
+        true
+      end
+
+      def get_options(_defined_options, result)
         # resolve all '<resource_name>_ids' parameters if they are defined as options
+        return result if @command.action.nil?
+
         available_ids_params.each do |api_param|
           param_resource = HammerCLIForeman.param_to_resource(api_param.name)
-          if result[HammerCLI.option_accessor_name(api_param.name)].nil? && param_updatable?(param_resource)
-            resource_ids = @command.get_resource_ids(param_resource, :scoped => true, :required => api_param.required?, :all_options => result)
-            result[HammerCLI.option_accessor_name(api_param.name)] = resource_ids if resource_ids
-          end
+          param_option = HammerCLI.option_accessor_name(api_param.name)
+          next unless needs_resolving?(param_option, param_resource, result)
+
+          resource_ids = @command.get_resource_ids(
+            param_resource, scoped: true, required: api_param.required?, all_options: result
+          )
+          result[param_option] = resource_ids if resource_ids
         end
         result
       end

--- a/test/unit/option_sources/id_params_test.rb
+++ b/test/unit/option_sources/id_params_test.rb
@@ -26,5 +26,14 @@ describe HammerCLIForeman::OptionSources::IdParams do
       params = id_params_source.get_options([], option_data)
       _(params).must_equal expected_data
     end
+
+    it 'resolves param when set but different name' do
+      hg_cmd.stubs(:get_resource_id).returns(nil)
+      hg_cmd.expects(:get_resource_id).with { |res| res.name == :domains }.returns(3)
+      option_data = { 'option_domain_id' => 1, 'option_domain_name' => 'test3' }
+      expected_data = { 'option_domain_id' => 3, 'option_domain_name' => 'test3' }
+      params = id_params_source.get_options([], option_data)
+      _(params).must_equal expected_data
+    end
   end
 end

--- a/test/unit/option_sources/ids_params_test.rb
+++ b/test/unit/option_sources/ids_params_test.rb
@@ -26,5 +26,14 @@ describe HammerCLIForeman::OptionSources::IdsParams do
       params = ids_params_source.get_options([], option_data)
       _(params).must_equal expected_data
     end
+
+    it "resolves param when set but different name" do
+      cmd.stubs(:get_resource_ids).returns(nil)
+      cmd.expects(:get_resource_ids).with { |res| res.name == :locations }.returns([3])
+      option_data = { 'option_location_ids' => [1], 'option_location_names' => 'test3' }
+      expected_data = { 'option_location_ids' => [3], 'option_location_names' => 'test3' }
+      params = ids_params_source.get_options([], option_data)
+      _(params).must_equal expected_data
+    end
   end
 end


### PR DESCRIPTION
The issue mentions that if the `~/.hammer/defaults.yml` contains
```yaml
:defaults:
  :organization_id:
    :value: '1'
  :organization:
    :value: 'Default Organization'
```
then option `--organization-id` internally will always be set to 1 when a user specifies a different value for `--organization` option instead of one in the defaults.

This patch allows to override default `*_id` param via corresponding command line options. For example if `defaults.yml` contains `:resource_id: 1`, but on the command line `--resource 'Resource Name'` was specified and it has `id: 3`, then it will use `id: 3`.

Note: the provided `defaults.yaml` is actually a bad usage of default values for options since there is no way to choose what actually should be used in case if `organization` has id different from one mentioned as `organization_id`.

To test this PR you'll need `~/.hammer/defaults.yml` similar to provided one, but with only one of `:orgnization_id`, `organization` being set.