### PR TITLE
Refs #28283 - Autodetect if apidoc cache needs reload

### DIFF
--- a/config/foreman.yml
+++ b/config/foreman.yml
@@ -37,6 +37,10 @@
   # Check API documentation cache status on each request
   #:refresh_cache: false
 
+  # Use checksum of installed plugins to automatically detect if the cache
+  # needs to be reloaded
+  :use_modules_checksum: true
+
   # API request timeout. Set to -1 for no timeout
   #:request_timeout: 120 #seconds
 

--- a/lib/hammer_cli_foreman/api/connection.rb
+++ b/lib/hammer_cli_foreman/api/connection.rb
@@ -22,8 +22,9 @@ module HammerCLIForeman
         auth_type ||= default_auth_type(settings)
         default_params = build_default_params(settings, logger, locale, auth_type)
         super(default_params,
-          :logger => logger,
-          :reload_cache => settings.get(:_params, :reload_cache) || settings.get(:reload_cache)
+          logger: logger,
+          reload_cache: settings.get(:_params, :reload_cache) || settings.get(:reload_cache),
+          use_modules_checksum: settings.get(:foreman, :use_modules_checksum) != false
         )
       end
 


### PR DESCRIPTION
Requires https://github.com/theforeman/hammer-cli/pull/359. Here it's enabled by default.