### PR TITLE
Fixes #28283 - Force API docs checksum check

### DIFF
--- a/lib/hammer_cli_foreman/api.rb
+++ b/lib/hammer_cli_foreman/api.rb
@@ -7,4 +7,5 @@ module HammerCLIForeman
   end
 end
 
-HammerCLIForeman.init_api_connection
+api = HammerCLIForeman.init_api_connection.api
+api.update_cache(api.check_cache)


### PR DESCRIPTION
This patch uses capabilities of `apipie-bindings` to fetch apipie checksum as well as loading new documentation file instead of inventing new ones. As was discussed in https://github.com/theforeman/hammer-cli/pull/359:

> If checking if local cache is fresh would be cheap enough then maybe hitting the server every time would be bearable?

I've checked `apipie-rails` once more and it seems like we can afford to make a call to the server just to check the cache. `apipie-rails` does computations of the checksum only once in the production unless configured otherwise. So it's pretty cheap to fetch a string especially without a need to do auths.

Other things considered:
 - https://github.com/theforeman/hammer-cli/pull/359 approach is... dumb.
 - Using `ETag` is not worth in this case, since we would need to compute checksum each call for the documentation.
 - `apipie-bindings` has an option called `aggressive_cache_checking`, but it would make hammer call checksum endpoint before each other call to the server, e.g. if hammer is used in `shell` mode then each command will do 2 calls instead of 1. This also won't solve the problem when the server has updated API docs, but hammer has the old one, and a user calls `hammer command action -h`, which won't show the new options. Moreover, if a new hammer plugin was installed and none of the commands were called then initialization of the hammer can fail.
 
 This patch forces the check for a newer version of API docs, but only at the initialization time, which should ensure we have always the latest docs file before we run any command (`--help` including). And in `hammer shell` mode we will do only one actual call per command (depending on the command of course).
 
 UPD: Checked in production, seems to resolve the issue...