### PR TITLE
Update foreman.yml

### DIFF
--- a/config/foreman.yml
+++ b/config/foreman.yml
@@ -3,6 +3,7 @@
   :enable_module: true
 
   # Your foreman server address
+  # For development try using http with the fully domain name.
   :host: 'https://localhost/'
 
   # Credentials. You'll be asked for them interactively if you leave them blank here


### PR DESCRIPTION
I'm using vanilla foreman and `:host: 'https://localhost/'` didn't work for me,
and caused the error:
```
Could not load the API description from the server: 
Failed to open TCP connection to localhost:443 (Address family not supported by protocol - socket(2) for "localhost" port 443)
  - is the server down?
  - was 'foreman-rake apipie:cache' run on the server when using apipie cache? (typical production settings)
Warning: An error occured while loading module hammer_cli_foreman.
```