### PR TITLE
use strings, not floats to denote ruby versions

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.7
-          - 3.0
-          - 3.1
+          - '2.7'
+          - '3.0'
+          - '3.1'
     steps:
       - name: Get hammer-cli
         uses: actions/checkout@v2


### PR DESCRIPTION
otherwise `3.0` is translated to `3` which means something different :)