### PR TITLE
Fixes #37163 - Use require_relative for 'coverage_reporter'

### DIFF
--- a/lib/minitest/hammer_coverage_plugin.rb
+++ b/lib/minitest/hammer_coverage_plugin.rb
@@ -1,4 +1,4 @@
-require 'coverage_reporter'
+require_relative 'coverage_reporter'
 require "json"
 
 module Minitest


### PR DESCRIPTION
Replace the usage of require with require_relative for 'coverage_reporter', ensuring that it is loaded relative to the current file's directory.