### PR TITLE
Refs #36999 - Drop CPU mode option for libvirt

### DIFF
--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -194,7 +194,6 @@ Available keys for `--compute-attributes`:
 ```
 cpus          # number of CPUs
 memory        # string, amount of memory, value in bytes
-cpu_mode      # possible values: default, host-model, host-passthrough
 start         # Must be a 1 or 0, whether to start the machine or not
 ```
 

--- a/lib/hammer_cli_foreman/compute_resource/libvirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/libvirt.rb
@@ -9,7 +9,6 @@ module HammerCLIForeman
         [
           ['cpus',   _('Number of CPUs'), { bold: true }],
           ['memory', _('String, amount of memory, value in bytes'), { bold: true }],
-          ['cpu_mode', _('Possible values: %{modes}') % { modes: 'default, host-model, host-passthrough' }],
           ['boot_order', _('Device names to specify the boot order')]
         ]
       end


### PR DESCRIPTION
This parameter is dropped from Foreman 3.12.