### PR TITLE
Fixes #37685 - Add Secure Boot and TPM options to VMware

### DIFF
--- a/doc/host_create.md
+++ b/doc/host_create.md
@@ -257,7 +257,7 @@ Available keys for `--compute-attributes`:
 cpus                  CPU count
 corespersocket        Number of cores per socket (applicable to hardware versions < 10 only)
 memory_mb             Integer number, amount of memory in MB
-firmware              automatic/bios/efi
+firmware              automatic/bios/uefi/uefi_secure_boot (UEFI with Secure Boot enabled)
 cluster               Cluster ID from VMware
 resource_pool         Resource Pool ID from VMware
 path                  Path to folder
@@ -270,6 +270,7 @@ annotation            Annotation Notes
 scsi_controllers      List with SCSI controllers definitions
                         type - ID of the controller from VMware
                         key  - Key of the controller (e.g. 1000)
+virtual_tpm           Must be a 1 or 0, Enable virtual TPM. Only compatible with EFI firmware
 start         # Must be a 1 or 0, whether to start the machine or not
 ```
 

--- a/lib/hammer_cli_foreman/compute_resource/vmware.rb
+++ b/lib/hammer_cli_foreman/compute_resource/vmware.rb
@@ -16,7 +16,7 @@ module HammerCLIForeman
           ['memory_mb',            _('Integer number, amount of memory in MB'), { bold: true }],
           ['path',                 _('Path to folder'), { bold: true }],
           ['resource_pool',        _('Resource Pool ID from VMware'), { bold: true }],
-          ['firmware',             'automatic/bios/efi'],
+          ['firmware',             _('automatic/bios/uefi/uefi_secure_boot (UEFI with Secure Boot enabled)')],
           ['guest_id',             _('Guest OS ID form VMware')],
           ['hardware_version',     _('Hardware version ID from VMware')],
           ['memoryHotAddEnabled',  _('Must be a 1 or 0, lets you add memory resources while the machine is on')],
@@ -26,10 +26,11 @@ module HammerCLIForeman
           ['scsi_controllers',     [_('List with SCSI controllers definitions'),
                                     '  type - ' + _('ID of the controller type from VMware'),
                                     '  key  - ' + _('Key of the controller (e.g. 1000)')].flatten(1).join("\n")],
-          ['nvme_controllers', [_('List with NVME controllers definitions'),
-                                '  type - ' + _('ID of the controller type from VMware'),
-                                '  key  - ' + _('Key of the controller (e.g. 2000)')].flatten(1).join("\n")],
-          ['boot_order', _('Device names to specify the boot order')]
+          ['nvme_controllers',     [_('List with NVME controllers definitions'),
+                                    '  type - ' + _('ID of the controller type from VMware'),
+                                    '  key  - ' + _('Key of the controller (e.g. 2000)')].flatten(1).join("\n")],
+          ['boot_order',           _('Device names to specify the boot order')],
+          ['virtual_tpm',          _('Must be a 1 or 0, Enable virtual TPM. Only compatible with EFI firmware.')]
         ]
       end
 
@@ -84,7 +85,9 @@ module HammerCLIForeman
           Fields::Field.new(label: _('Path'), path: [:path]),
           Fields::Field.new(label: _('Operating System'), path: [:operatingsystem]),
           Fields::Field.new(label: _('Mac'), path: [:mac]),
-          Fields::List.new(label: _('Boot order'), path: [:boot_order])
+          Fields::List.new(label: _('Boot order'), path: [:boot_order]),
+          Fields::Field.new(label: _('Virtual TPM'), path: [:virtual_tpm]),
+          Fields::Field.new(label: _('Secure Boot'), path: [:secure_boot])
         ]
       end
 


### PR DESCRIPTION
- Add `uefi_secure_boot` firmware for UEFI with Secure Boot enabled.
- Add `virtual_tpm` option to compute-attributes.

Requires:
- https://github.com/theforeman/foreman/pull/10324
- https://github.com/fog/fog-vsphere/pull/305