### PR TITLE
Fixes #37692 - Add firmware option for Libvirt hosts creation

### DIFF
--- a/lib/hammer_cli_foreman/compute_resource/libvirt.rb
+++ b/lib/hammer_cli_foreman/compute_resource/libvirt.rb
@@ -10,7 +10,8 @@ module HammerCLIForeman
           ['cpus',   _('Number of CPUs'), { bold: true }],
           ['memory', _('String, amount of memory, value in bytes'), { bold: true }],
           ['cpu_mode', _('Possible values: %{modes}') % { modes: 'default, host-model, host-passthrough' }],
-          ['boot_order', _('Device names to specify the boot order')]
+          ['boot_order', _('Device names to specify the boot order')],
+          ['firmware', _('automatic/bios/efi/uefi_sb (EFI with Secure Boot enabled)')]
         ]
       end
 
@@ -50,7 +51,8 @@ module HammerCLIForeman
             Fields::Field.new(:label => _('OS Type'), :path => [:os_type]),
             Fields::Field.new(:label => _('Domain Type'), :path => [:domain_type]),
             Fields::Field.new(:label => _('Persistent'), :path => [:persistent]),
-            Fields::List.new(:label => _('Boot order'), :path => [:boot_order])
+            Fields::List.new(:label => _('Boot order'), :path => [:boot_order]),
+            Fields::Field.new(:label => _('Secure Boot'), :path => [:secure_boot])
         ]
       end
 


### PR DESCRIPTION
New `firmware` option for creating new hosts in Libvirt, allowing users to specify the VM firmware type, including Secure Boot.