### PR TITLE
Fixes #38291 - fix hammer host update error messages

### DIFF
--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -98,9 +98,11 @@ module HammerCLIForeman
       begin
         response = JSON.parse(e.response)
         response = HammerCLIForeman.record_to_common_format(response) unless response.has_key?('message')
-        message = response['message'] || e.message
+        message = response["displayMessage"] || response["full_messages"] || response["message"]
       rescue JSON::ParserError
         message = e.message
+      ensure
+        message ||= e.message
       end
 
       print_error message


### PR DESCRIPTION
This should fix https://projects.theforeman.org/issues/38253 and a few other issues with `hammer host update`.

The Foreman exception handler doesn't look at `displayMessage` in the response, but that's where the error message is.

So with this change, instead of 
```
Could not update the host:
  500 Internal Server Error
```

you'll get the actual error message (for example):

```
Could not update the host:
  RuntimeError: Cannot assign content view environment elephant/centos_old: The content view has either not been published or has not been promoted to that lifecycle environment.
```

