### PR TITLE
Fixes #38401 - Fix hammer insights inventory sync error message

### DIFF
--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -170,7 +170,8 @@ module HammerCLIForeman
     end
 
     def response_message(response)
-      message = JSON.parse(response)["error"]["message"]
+      result = JSON.parse(response)
+      message = result.dig("error", "message") || result.dig("message")
       "\n  #{message}"
     rescue JSON::ParserError
       ''


### PR DESCRIPTION
Create an organization with no hosts to sync.

```
hammer insights inventory sync --organization-id=1
```

Before 
```
Error: undefined method `[]' for nil:NilClass
```
After
```
Failed to start inventory sync task, please check server logs for more information:
  400 Bad Request
    ERF74-6085 [InventoryUpload::TaskActions::NothingToSyncError]: Nothing to sync, there are no hosts with subscription for this organization.
```