### PR TITLE
Expose cloned from id in template info command

### DIFF
--- a/lib/hammer_cli_foreman/report_template.rb
+++ b/lib/hammer_cli_foreman/report_template.rb
@@ -16,6 +16,7 @@ module HammerCLIForeman
       output ListCommand.output_definition do
         field :description, _('Description'), Fields::Text
         field :locked, _("Locked"), Fields::Boolean
+        field :cloned_from_id, _("Cloned from id"), nil, :hide_blank => true
         field :default, _("Default"), Fields::Boolean
         HammerCLIForeman::References.timestamps(self)
         HammerCLIForeman::References.taxonomies(self)

--- a/lib/hammer_cli_foreman/template.rb
+++ b/lib/hammer_cli_foreman/template.rb
@@ -42,6 +42,7 @@ module HammerCLIForeman
       output ListCommand.output_definition do
         field :description, _('Description'), Fields::Text
         field :locked, _("Locked"), Fields::Boolean
+        field :cloned_from_id, _("Cloned from id"), nil, :hide_blank => true
         HammerCLIForeman::References.operating_systems(self)
         HammerCLIForeman::References.taxonomies(self)
         collection :template_combinations, 'Template Combinations' do


### PR DESCRIPTION
Exposed `cloned_from_id` in the template and report-template info commands if exists.