### PR TITLE
Bump to 5.0.0-develop

### DIFF
--- a/lib/hammer_cli_foreman/version.rb
+++ b/lib/hammer_cli_foreman/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIForeman
   def self.version
-    @version ||= Gem::Version.new "3.20.0-develop"
+    @version ||= Gem::Version.new "5.0.0-develop"
   end
 end


### PR DESCRIPTION
## Summary
- Bump version from 3.20.0-develop to 5.0.0-develop

## Test plan
- [x] Verify `HammerCLIForeman.version` returns 5.0.0-develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)