### PR TITLE
Fixes #39372 - Extract displayMessage from validation errors

### DIFF
--- a/lib/hammer_cli_foreman/exception_handler.rb
+++ b/lib/hammer_cli_foreman/exception_handler.rb
@@ -35,7 +35,7 @@ module HammerCLIForeman
     def handle_unprocessable_entity(e)
       response = JSON.parse(e.response)
       response = HammerCLIForeman.record_to_common_format(response) unless response.has_key?('message')
-      print_error response['message'] || response['full_messages']
+      print_error response['message'] || response['full_messages'] || response['displayMessage']
       HammerCLI::EX_DATAERR
     end
 

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -29,6 +29,17 @@ describe HammerCLIForeman::ExceptionHandler do
     _(err_code).must_equal HammerCLI::EX_DATAERR
   end
 
+  it "should print displayMessage on unprocessable entity exception" do
+    response = <<-RESPONSE
+    {"displayMessage":"Validation failed: Cannot add content view environment to content facet.","errors":{"base":["Cannot add content view environment to content facet."]}}
+    RESPONSE
+
+    ex = RestClient::UnprocessableEntity.new(response)
+    output.expects(:print_error).with(heading, "Validation failed: Cannot add content view environment to content facet.")
+    err_code = handler.handle_exception(ex, :heading => heading)
+    _(err_code).must_equal HammerCLI::EX_DATAERR
+  end
+
   it "should handle argument error" do
     ex = ArgumentError.new
     output.expects(:print_error).with(heading, ex.message)


### PR DESCRIPTION
When the Foreman/Katello API returns validation errors (422 status), it includes detailed error messages in the 'displayMessage' field. The exception handler was only checking 'message' and 'full_messages', causing detailed error information to be lost.

This commit updates handle_unprocessable_entity to check for 'displayMessage' first, matching the behavior of handle_foreman_error which already handles this field correctly.

Before:
  Could not update the host

After:
  Could not update the host:
    Validation failed: Host example.com: Cannot add content view
    environment to content facet. The host's content source does
    not sync lifecycle environment 'Library'.

#### Before patch:
```bash
hammer -d host update --id 3 --content-view-environments Library/Zoo
Could not update the host.
```

#### After patch:
```bash
hammer host update --id 3 --content-view-environments Library/Zoo
Could not update the host:
Validation failed: Host host.example.com: Cannot add content view environment to content facet. The host's content source 'capsule.example.com' does not sync lifecycle environment 'Library'.
```

#### Testing Steps:

1. Create multiple Content Views (e.g., cv_1 & cv_2) and multiple Lifecycle Environments (e.g., 'Library' and 'Dev').

2. Publish new versions of all Content Views and promote them to the 'Dev' lifecycle environment.

3. Add only the 'Dev' lifecycle environment to the external Capsule, ensuring that the 'Library' lifecycle environment is not added. Then, synchronize the Capsule server.

4. Register the client to the Capsule server.

5. Try to update the hosts content view environments to one not synced on the capsule
`hammer -d host update --id 3 --content-view-environments Library/Zoo`

6. Verify you see the real error and not the generic can't update host error