### PR TITLE
Fixes #39414 - Show unrecognized smart proxy features in list and info

### DIFF
--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -32,9 +32,16 @@ module HammerCLIForeman
           field :name, _('Name')
           field :version, _('Version')
         end
-        field :unrecognized_features, _("Unrecognized features"), Fields::List, :hide_blank => true
+        collection :_unrecognized_features, _("Unrecognized features"), :hide_blank => true do
+          field :name, _('Name')
+        end
         HammerCLIForeman::References.taxonomies(self)
         HammerCLIForeman::References.timestamps(self)
+      end
+
+      def extend_data(proxy)
+        proxy['_unrecognized_features'] = (proxy['unrecognized_features'] || []).map { |f| { 'name' => f } }
+        proxy
       end
 
       build_options

--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -40,7 +40,7 @@ module HammerCLIForeman
       end
 
       def extend_data(proxy)
-        proxy['_unrecognized_features'] = (proxy['unrecognized_features'] || []).map { |f| { 'name' => f } }
+        proxy['_unrecognized_features'] = proxy['unrecognized_features'].map { |f| { 'name' => f } } if proxy['unrecognized_features']
         proxy
       end
 

--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -13,6 +13,7 @@ module HammerCLIForeman
         field :status, _("Status")
         field :url, _("URL")
         field :_features, _( "Features"), Fields::List, :hide_blank => true
+        field :unrecognized_features, _("Unrecognized features"), Fields::List, :hide_blank => true
       end
 
       def extend_data(proxy)
@@ -31,6 +32,7 @@ module HammerCLIForeman
           field :name, _('Name')
           field :version, _('Version')
         end
+        field :unrecognized_features, _("Unrecognized features"), Fields::List, :hide_blank => true
         HammerCLIForeman::References.taxonomies(self)
         HammerCLIForeman::References.timestamps(self)
       end

--- a/lib/hammer_cli_foreman/smart_proxy.rb
+++ b/lib/hammer_cli_foreman/smart_proxy.rb
@@ -40,7 +40,7 @@ module HammerCLIForeman
       end
 
       def extend_data(proxy)
-        proxy['_unrecognized_features'] = proxy['unrecognized_features'].map { |f| { 'name' => f } } if proxy['unrecognized_features']
+        proxy['_unrecognized_features'] = proxy.delete('unrecognized_features').map { |f| { 'name' => f } } if proxy['unrecognized_features']
         proxy
       end
 


### PR DESCRIPTION
Companion to https://github.com/theforeman/foreman/pull/11017

Display unrecognized_features from the Foreman API response in both the list and info commands, hidden when blank.

```
# bundle exec ruby bin/hammer proxy list
---|-----------|-----------------------|-----------------------|----------------------
ID | NAME      | URL                   | FEATURES              | UNRECOGNIZED FEATURES
---|-----------|-----------------------|-----------------------|----------------------
1  | localhost | http://localhost:8000 | Dynflow, Script, Logs | openscap
---|-----------|-----------------------|-----------------------|----------------------
```

```
# bundle exec ruby bin/hammer proxy info --id 1
Id:                    1
Name:                  localhost
URL:                   http://localhost:8000
Unrecognized features: openscap
Host count:            0
Features:
 1) Name: Dynflow
 2) Name: Script
 3) Name: Logs
Unrecognized features: openscap
Locations:
    Default Location
Organizations:
    Default Organization
Created at:            2026/01/05 13:23:58
Updated at:            2026/06/10 13:43:27
```

To be squashed on merge