### PR TITLE
Fixes #39537 - Implement LDAP CA cert support

### DIFF
--- a/lib/hammer_cli_foreman/auth_source_ldap.rb
+++ b/lib/hammer_cli_foreman/auth_source_ldap.rb
@@ -7,14 +7,9 @@ module HammerCLIForeman
     module CacertFileOption
       def self.included(base)
         base.option '--cacert-file', 'CACERT_FILE',
-                    _('Path to a PEM file containing CA certificate(s) for LDAPS verification. Ignored if --cacert is set'),
+                    _('Path to a PEM file with CA certificate(s) added to the system trust store for LDAPS verification'),
+                    :attribute_name => :option_cacert,
                     :format => HammerCLI::Options::Normalizers::File.new
-      end
-
-      def request_params
-        params = super
-        params['auth_source_ldap']['cacert'] ||= options['option_cacert_file'] if options['option_cacert_file']
-        params
       end
     end
 
@@ -70,7 +65,9 @@ module HammerCLIForeman
       success_message _('Auth source [%{name}] created.')
       failure_message _('Could not create the Auth Source')
 
-      build_options
+      build_options do |o|
+        o.without(:cacert)
+      end
     end
 
     class DeleteCommand < HammerCLIForeman::DeleteCommand
@@ -86,7 +83,9 @@ module HammerCLIForeman
       success_message _('Auth source [%{name}] updated.')
       failure_message _('Could not update the Auth Source')
 
-      build_options
+      build_options do |o|
+        o.without(:cacert)
+      end
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_foreman/auth_source_ldap.rb
+++ b/lib/hammer_cli_foreman/auth_source_ldap.rb
@@ -7,7 +7,7 @@ module HammerCLIForeman
     module CacertFileOption
       def self.included(base)
         base.option '--cacert-file', 'CACERT_FILE',
-                    _('Path to a PEM file with CA certificate(s) used for LDAPS verification (system trust store is not used when set)'),
+                    _('Path to a PEM file with CA certificate(s) used for LDAPS verification (system trust store is not used when set). In containerized deployments, the container\'s trust store is used, so the CA certificate(s) may need to be provided here explicitly'),
                     :attribute_name => :option_cacert,
                     :format => HammerCLI::Options::Normalizers::File.new
       end

--- a/lib/hammer_cli_foreman/auth_source_ldap.rb
+++ b/lib/hammer_cli_foreman/auth_source_ldap.rb
@@ -7,7 +7,7 @@ module HammerCLIForeman
     module CacertFileOption
       def self.included(base)
         base.option '--cacert-file', 'CACERT_FILE',
-                    _('Path to a PEM file with CA certificate(s) added to the system trust store for LDAPS verification'),
+                    _('Path to a PEM file with CA certificate(s) used for LDAPS verification (system trust store is not used when set)'),
                     :attribute_name => :option_cacert,
                     :format => HammerCLI::Options::Normalizers::File.new
       end

--- a/lib/hammer_cli_foreman/auth_source_ldap.rb
+++ b/lib/hammer_cli_foreman/auth_source_ldap.rb
@@ -4,6 +4,20 @@ module HammerCLIForeman
     command_name 'ldap'
     desc _('Manage LDAP auth sources')
 
+    module CacertFileOption
+      def self.included(base)
+        base.option '--cacert-file', 'CACERT_FILE',
+                    _('Path to a PEM file containing CA certificate(s) for LDAPS verification. Ignored if --cacert is set'),
+                    :format => HammerCLI::Options::Normalizers::File.new
+      end
+
+      def request_params
+        params = super
+        params['auth_source_ldap']['cacert'] ||= options['option_cacert_file'] if options['option_cacert_file']
+        params
+      end
+    end
+
     class ListCommand < HammerCLIForeman::ListCommand
       output do
         field :id, _('Id')
@@ -23,6 +37,7 @@ module HammerCLIForeman
           field :name, _('Name')
           field :host, _('Server')
           field :tls, _('LDAPS'), Fields::Boolean
+          field :cacert, _('CA certificate'), Fields::LongText, :hide_blank => true
           field :port, _('Port')
           field :server_type, _('Server Type')
         end
@@ -50,6 +65,8 @@ module HammerCLIForeman
     end
 
     class CreateCommand < HammerCLIForeman::CreateCommand
+      include CacertFileOption
+
       success_message _('Auth source [%{name}] created.')
       failure_message _('Could not create the Auth Source')
 
@@ -64,6 +81,8 @@ module HammerCLIForeman
     end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
+      include CacertFileOption
+
       success_message _('Auth source [%{name}] updated.')
       failure_message _('Could not update the Auth Source')
 

--- a/test/unit/auth_source_ldap_test.rb
+++ b/test/unit/auth_source_ldap_test.rb
@@ -60,6 +60,7 @@ describe HammerCLIForeman::AuthSourceLdap do
 
     describe "parameters" do
       it_should_accept "all required params", ["--name=arch", "--host=my.host"]
+      it_should_accept "cacert file", ["--name=arch", "--host=my.host", "--cacert-file=#{__FILE__}"]
       # it_should_fail_with "name missing", []
       # TODO: temporarily disabled, parameters are checked in the api
     end
@@ -87,6 +88,7 @@ describe HammerCLIForeman::AuthSourceLdap do
     describe "parameters" do
       it_should_accept "name", ["--name=arch", "--new-name=arch2"]
       it_should_accept "id", ["--id=1", "--new-name=arch2"]
+      it_should_accept "cacert file", ["--id=1", "--cacert-file=#{__FILE__}"]
       # it_should_fail_with "no params", [] # TODO: temporarily disabled, parameters are checked in the id resolver
       # it_should_fail_with "name or id missing", ["--new-name=arch2"] # TODO: temporarily disabled, parameters are checked in the id resolver
     end


### PR DESCRIPTION
Cacert can be provided as file or string.

Made with Cursor.

Requires https://github.com/theforeman/foreman/pull/11107